### PR TITLE
ci: fix container workflow failures (Fixes #41)

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -19,6 +19,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      security-events: write  # Required for uploading Trivy SARIF results
 
     steps:
       - name: Checkout code
@@ -65,7 +66,7 @@ jobs:
           output: 'trivy-results.sarif'
 
       - name: Upload Trivy results to GitHub Security
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: 'trivy-results.sarif'
 


### PR DESCRIPTION
## Problem

The Container Build & Push workflow has been failing continuously since PR #26 with the error "Resource not accessible by integration" when uploading Trivy security scan results.

**Impact:**
- 8+ consecutive workflow failures on main branch
- Security scan results not appearing in GitHub Security tab
- Creates noise and reduces confidence in CI/CD pipeline

## Root Cause

Missing `security-events: write` permission in workflow configuration, preventing SARIF file upload to GitHub Security tab.

## Changes

1. **Added `security-events: write` permission** - Allows workflow to upload Trivy SARIF results to GitHub Security tab
2. **Updated CodeQL action from v3 to v4** - Proactive fix for deprecation warning (v3 deprecates December 2026)

## Testing

✅ Tested via `workflow_dispatch` on branch `ci/issue-41-fix-container-workflow`
✅ All workflow steps passed successfully (run #21783071756)
✅ Trivy security scan uploaded successfully to Security tab
✅ Container health checks passed
✅ No "Resource not accessible" errors

## Verification

**Before:**
- Workflow success rate: 0% (8/8 failures)
- SARIF uploads: 0

**After (test run):**
- Workflow success rate: 100%
- All 7 workflow steps passed
- SARIF upload successful

## Files Changed

- `.github/workflows/container.yml` (2 lines)
  - Line 22: Added `security-events: write` permission
  - Line 68: Updated `github/codeql-action/upload-sarif@v3` → `@v4`

## Expected Outcome

After merge:
- ✅ Container workflow passes on all future runs
- ✅ Trivy security scan results visible in GitHub Security tab
- ✅ No more permission errors
- ✅ Clean workflow status in Actions tab

Fixes #41