### PR TITLE
docs: document container security scanning (Fixes #45)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -519,6 +519,30 @@ docker-compose up -d
 docker-compose --profile dev up timezone-app-dev
 ```
 
+#### Security Scanning
+
+Container images are automatically scanned with Trivy during the build process via the Container Build & Push workflow (`.github/workflows/container.yml`). Scan results are uploaded to the GitHub Security tab for vulnerability tracking.
+
+**Required Permissions:**
+- `security-events: write` - Required for uploading SARIF scan results to GitHub Security tab
+- `packages: write` - Required for pushing images to GitHub Container Registry
+
+**Scan Configuration:**
+- **Tool:** Trivy (Aqua Security)
+- **Format:** SARIF (Security Alerts Results Interchange Format)
+- **Frequency:** On every push to main and tagged releases
+- **Results:** Available in GitHub Security tab under Code Scanning
+
+**Workflow Integration:**
+The Container Build & Push workflow automatically:
+1. Builds multi-architecture container images (amd64, arm64)
+2. Pushes images to GitHub Container Registry (ghcr.io)
+3. Runs Trivy security scan on the built image
+4. Uploads scan results to GitHub Security tab
+5. Performs container health checks
+
+**Reference:** See PR #42 for the security scanning implementation details.
+
 ### Kubernetes Deployment
 
 **Note:** Full Kubernetes manifest files are planned for future implementation. See `docs/CI-CD-IMPROVEMENTS.md` for tracking.

--- a/docs/CI-CD-IMPROVEMENTS.md
+++ b/docs/CI-CD-IMPROVEMENTS.md
@@ -191,6 +191,38 @@ kubectl logs <pod-name>
 
 ## Completed ✅
 
+### Container Workflow Permission Fix
+- **Completed:** 2026-02-07
+- **Duration:** 30 minutes
+- **Impact:** High
+- **Owner:** olaoluthomas
+
+**What Was Implemented:**
+- Added `security-events: write` permission to Container Build & Push workflow
+- Updated CodeQL action from v3 to v4 (proactive deprecation fix)
+- Fixed continuous workflow failures since PR #26
+
+**Problem:**
+The Container Build & Push workflow had been failing continuously with "Resource not accessible by integration" error when attempting to upload Trivy security scan results to GitHub Security tab.
+
+**Solution:**
+Added missing `security-events: write` permission required for SARIF file upload to GitHub Security tab.
+
+**Results:**
+- Workflow success rate: 0% → 100%
+- Trivy security scan results now visible in GitHub Security tab
+- Container deployments unblocked
+- No more "Resource not accessible" errors
+- Future-proofed with CodeQL v4 (v3 deprecates December 2026)
+
+**Files:**
+- `.github/workflows/container.yml`
+
+**GitHub Issue:** #41
+**Pull Request:** #42
+
+---
+
 ### Pre-commit and Pre-push Hooks
 - **Completed:** 2026-01-24
 - **Duration:** 2 hours


### PR DESCRIPTION
## Purpose

Document the container security scanning workflow that was added in PR #42.

## Changes

### Documentation Updates
- **`docs/CI-CD-IMPROVEMENTS.md`**: Added "Container Workflow Permission Fix" to completed improvements section
- **`docs/ARCHITECTURE.md`**: Added "Security Scanning" subsection documenting Trivy integration

## Context

The container workflow fix (PR #42) successfully resolved workflow failures by adding the `security-events: write` permission required for uploading Trivy security scan results to GitHub Security tab. This PR adds proper documentation for that feature.

### What Was Fixed in PR #42
- Added `security-events: write` permission to Container Build & Push workflow
- Updated CodeQL action from v3 to v4 (proactive deprecation fix)
- Fixed continuous workflow failures since PR #26
- Workflow success rate: 0% → 100%

### Documentation Added
- Required permissions for security scanning
- Trivy scan configuration and frequency
- Workflow integration steps
- Reference to GitHub Security tab for scan results

## Files Changed
- `docs/CI-CD-IMPROVEMENTS.md` (added container workflow section)
- `docs/ARCHITECTURE.md` (added security scanning subsection)

## References

- **Issue:** #45
- **Related Issue:** #41 (original container workflow issue)
- **Related PR:** #42 (container workflow fix)

Fixes #45