### PR TITLE
docs: add LOG_LEVEL to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,11 @@
 PORT=3000
 NODE_ENV=development
 
+# Logging Configuration
+# Log level: debug, info, warn, error
+# Defaults: 'debug' in development, 'info' in production
+LOG_LEVEL=debug
+
 # CORS Configuration
 # Comma-separated list of allowed origins (production only)
 # In development, all origins are allowed


### PR DESCRIPTION
## Summary
- Add LOG_LEVEL environment variable to .env.example
- Include documentation for available log levels (debug, info, warn, error)
- Document defaults (debug in development, info in production)

## Changes
- Added "Logging Configuration" section to .env.example
- Positioned between Server Configuration and CORS Configuration sections
- Set LOG_LEVEL=debug as the default value for development environment

## Test Plan
- [x] Verified .env.example syntax is correct
- [x] Confirmed all required environment variables are now documented
- [x] Pre-push checks passed (ESLint, Prettier, security audit, tests)

Fixes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)