### PR TITLE
fix: make CI workflow depend on PR validation success

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  # Push events to feature branches (direct trigger, no validation needed)
   push:
     branches:
       - 'feature/**'
@@ -18,18 +19,14 @@ on:
       - '.gitattributes'
       - '.github/pull_request_template.md'
       - '.editorconfig'
-  pull_request:
+
+  # Pull requests: only run after PR validation succeeds
+  workflow_run:
+    workflows: ["PR Validation"]
+    types: [completed]
     branches: [main]
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - 'LICENSE'
-      - 'AUTHORS'
-      - 'NOTICE'
-      - '.gitignore'
-      - '.gitattributes'
-      - '.github/pull_request_template.md'
-      - '.editorconfig'
+
+  # Manual trigger
   workflow_dispatch:
 
 # Cancel outdated runs when new commits are pushed
@@ -38,10 +35,61 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Job 0: Check if we should run (validation passed or push event)
+  check-trigger:
+    name: Check Workflow Trigger
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.check.outputs.should_run }}
+    steps:
+      - name: Checkout code (for path filtering)
+        uses: actions/checkout@v4
+        if: github.event_name == 'workflow_run'
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Check trigger conditions
+        id: check
+        run: |
+          echo "Event name: ${{ github.event_name }}"
+
+          # For push/workflow_dispatch, always run
+          if [[ "${{ github.event_name }}" == "push" ]] || \
+             [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "should_run=true" >> $GITHUB_OUTPUT
+            echo "✅ Workflow should run (push/manual trigger)"
+            exit 0
+          fi
+
+          # For workflow_run (PR validation), check conclusion and paths
+          if [[ "${{ github.event.workflow_run.conclusion }}" != "success" ]]; then
+            echo "should_run=false" >> $GITHUB_OUTPUT
+            echo "⏭️  Skipping workflow (PR validation failed)"
+            exit 0
+          fi
+
+          # Check if only docs/markdown changed
+          CHANGED_FILES=$(git diff --name-only ${{ github.event.workflow_run.head_sha }}^..${{ github.event.workflow_run.head_sha }})
+          echo "Changed files:"
+          echo "$CHANGED_FILES"
+
+          # Filter out ignored paths
+          RELEVANT_CHANGES=$(echo "$CHANGED_FILES" | grep -vE '\.(md)$|^docs/|^LICENSE|^AUTHORS|^NOTICE|^\.gitignore|^\.gitattributes|^\.github/pull_request_template\.md|^\.editorconfig' || true)
+
+          if [[ -z "${RELEVANT_CHANGES}" ]]; then
+            echo "should_run=false" >> $GITHUB_OUTPUT
+            echo "⏭️  Skipping workflow (only documentation changes)"
+          else
+            echo "should_run=true" >> $GITHUB_OUTPUT
+            echo "✅ Workflow should run (code changes detected)"
+          fi
+
   # Job 1: Lint and Format Check
   lint:
     name: Lint & Format Check
     runs-on: ubuntu-latest
+    needs: check-trigger
+    if: needs.check-trigger.outputs.should_run == 'true'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -72,6 +120,8 @@ jobs:
   security:
     name: Security Audit
     runs-on: ubuntu-latest
+    needs: check-trigger
+    if: needs.check-trigger.outputs.should_run == 'true'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -103,6 +153,8 @@ jobs:
       matrix:
         node-version: [18.x, 20.x]
       fail-fast: false
+    needs: check-trigger
+    if: needs.check-trigger.outputs.should_run == 'true'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -134,6 +186,8 @@ jobs:
       matrix:
         node-version: [18.x, 20.x]
       fail-fast: false
+    needs: check-trigger
+    if: needs.check-trigger.outputs.should_run == 'true'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -165,6 +219,8 @@ jobs:
       matrix:
         node-version: [18.x, 20.x]
       fail-fast: false
+    needs: check-trigger
+    if: needs.check-trigger.outputs.should_run == 'true'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -192,7 +248,8 @@ jobs:
   coverage:
     name: Coverage Report
     runs-on: ubuntu-latest
-    needs: [test-unit, test-integration, test-smoke]
+    needs: [check-trigger, test-unit, test-integration, test-smoke]
+    if: needs.check-trigger.outputs.should_run == 'true'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -227,6 +284,8 @@ jobs:
   build:
     name: Build Verification
     runs-on: ubuntu-latest
+    needs: check-trigger
+    if: needs.check-trigger.outputs.should_run == 'true'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

This PR fixes the GitHub Actions workflow dependencies so that the CI workflow only runs when PR validation passes and code files are changed.

## Changes

- Changed CI trigger from `pull_request` to `workflow_run` (depends on PR Validation)
- Added `check-trigger` job to verify validation passed and code changed
- Added path filtering for documentation-only changes
- Updated all CI jobs to depend on `check-trigger`

## Benefits

- ✅ Validation always runs for all PRs (ensures labels/title)
- ✅ CI only runs when validation passes (saves resources)  
- ✅ Documentation PRs skip expensive CI tests
- ✅ Clear separation of concerns (validation vs testing)

## Testing

This creates a two-tier validation system:
1. **Tier 1 (Always)**: PR validation checks labels and commit format for ALL PRs
2. **Tier 2 (Conditional)**: CI runs only if validation passes AND code files changed

🤖 Generated with Claude Code