### PR TITLE
docs: standardize GitHub MCP-first instructions across documentation

### DIFF
--- a/PROJECT-CONTEXT.md
+++ b/PROJECT-CONTEXT.md
@@ -219,10 +219,9 @@ The application is production-ready with:
 Before making any code changes for bugs, features, or enhancements:
 
 1. **Create a GitHub Issue** (mandatory)
-   ```bash
-   gh issue create --title "fix: Brief description" --label "bug"
-   # OR
-   gh issue create --title "feat: Brief description" --label "enhancement"
+   ```
+   # Preferred: GitHub MCP issue_write (method: create, owner: olaoluthomas, repo: timezone-app)
+   # Fallback:  gh issue create --title "fix: Brief description" --label "bug"
    ```
 
 2. **Create a branch referencing the issue**
@@ -240,7 +239,10 @@ Before making any code changes for bugs, features, or enhancements:
 4. **Push and create PR**
    ```bash
    git push -u origin branch-name
-   gh pr create --title "fix: description (Fixes #N)"
+   ```
+   ```
+   # Preferred: GitHub MCP create_pull_request (with labels)
+   # Fallback:  npm run create-pr
    ```
 
 ### Branch Naming Convention

--- a/README.md
+++ b/README.md
@@ -100,12 +100,13 @@ See [Configuration Guide](docs/development/CONFIGURATION.md) for advanced option
 
 Contributions welcome! Follow the **mandatory issue-first workflow**:
 
-```bash
-gh issue create --title "type: description" --label "type"
+```
+# 1. Create issue — Preferred: GitHub MCP issue_write | Fallback: gh issue create
+# 2. Branch, commit, push
 git checkout -b type/issue-N-description
 git commit -m "type: description"
 git push -u origin type/issue-N-description
-gh pr create --title "type: description (Fixes #N)"
+# 3. Create PR — Preferred: GitHub MCP create_pull_request | Fallback: npm run create-pr
 ```
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for full details.

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -6,7 +6,8 @@
 
 ```bash
 # Step 1: Create GitHub Issue (MANDATORY)
-gh issue create --title "type: brief description" --label "type"
+# Preferred: GitHub MCP issue_write (method: create)
+# Fallback:  gh issue create --title "type: brief description" --label "type"
 # Returns: Created issue #N
 
 # Step 2: Create Branch (MUST reference issue number)
@@ -19,8 +20,9 @@ git commit -m "type: description of changes"
 # Step 4: Push Branch
 git push -u origin type/issue-N-short-description
 
-# Step 5: Create Pull Request (Use automated script)
-npm run create-pr
+# Step 5: Create Pull Request
+# Preferred: GitHub MCP create_pull_request (with labels from commit type + changed files)
+# Fallback:  npm run create-pr
 ```
 
 ## Branch Naming Convention
@@ -93,7 +95,8 @@ git commit -m "some changes"
 
 ```bash
 # 1. Create issue
-gh issue create --title "feat: Add timezone converter" --label "enhancement"
+# Preferred: GitHub MCP issue_write (method: create, title: "feat: Add timezone converter", labels: ["enhancement"])
+# Fallback:  gh issue create --title "feat: Add timezone converter" --label "enhancement"
 # Returns: Created issue #42
 
 # 2. Create branch
@@ -105,14 +108,15 @@ git commit -m "feat: add timezone converter endpoint"
 
 # 4. Push and create PR
 git push -u origin feat/issue-42-timezone-converter
-npm run create-pr
+# Preferred: GitHub MCP create_pull_request | Fallback: npm run create-pr
 ```
 
 ### Fixing a Bug
 
 ```bash
 # 1. Create issue
-gh issue create --title "fix: Rate limiting broken on localhost" --label "bug"
+# Preferred: GitHub MCP issue_write (method: create, title: "fix: Rate limiting broken on localhost", labels: ["bug"])
+# Fallback:  gh issue create --title "fix: Rate limiting broken on localhost" --label "bug"
 # Returns: Created issue #14
 
 # 2. Create branch
@@ -126,14 +130,15 @@ git commit -m "fix: resolve rate limiting issue for localhost"
 git push -u origin fix/issue-14-rate-limit-localhost
 
 # 5. Create PR
-npm run create-pr
+# Preferred: GitHub MCP create_pull_request | Fallback: npm run create-pr
 ```
 
 ### Refactoring Code
 
 ```bash
 # 1. Create issue
-gh issue create --title "refactor: Remove unnecessary Promise.resolve wrapper" --label "refactor"
+# Preferred: GitHub MCP issue_write (method: create, title: "refactor: Remove unnecessary Promise.resolve wrapper", labels: ["refactor"])
+# Fallback:  gh issue create --title "refactor: Remove unnecessary Promise.resolve wrapper" --label "refactor"
 # Returns: Created issue #37
 
 # 2. Create branch
@@ -147,25 +152,25 @@ git commit -m "refactor: remove unnecessary Promise.resolve() wrapper"
 git push -u origin refactor/issue-37-remove-promise-resolve
 
 # 5. Create PR
-npm run create-pr
+# Preferred: GitHub MCP create_pull_request | Fallback: npm run create-pr
 ```
 
 ## Creating Pull Requests
 
-**⚠️ REQUIRED: Use the automated PR creation script**
+**Preferred: GitHub MCP `create_pull_request`** with labels derived from commit type and changed files (see labeling logic in `scripts/create-pr.sh`).
+
+**Fallback: Automated PR creation script**
 
 ```bash
 npm run create-pr
 ```
 
-This is the **ONLY** supported way to create PRs. Benefits:
+Benefits of the automated script:
 - ✅ **Auto-labels**: Applies labels based on commit type and changed files
 - ✅ **Consistent format**: Generates standardized PR descriptions
 - ✅ **Issue linking**: Automatically links to related issues
 - ✅ **Reviewer assignment**: Assigns appropriate reviewers
 - ✅ **Validation**: Ensures PR follows project conventions
-
-**DO NOT use `gh pr create` directly** - this bypasses automated labeling and validation.
 
 ### How Labels Are Applied
 
@@ -189,7 +194,7 @@ The script automatically labels PRs based on:
 ## PR Requirements
 
 All PRs **MUST**:
-- ✅ Be created using `npm run create-pr` (not manual `gh pr create`)
+- ✅ Be created using GitHub MCP `create_pull_request` (preferred) or `npm run create-pr` (fallback)
 - ✅ Reference issue number in commit messages and PR
 - ✅ Pass all CI checks (10/10 green)
 - ✅ Follow conventional commit format
@@ -222,14 +227,15 @@ git checkout -b add-feature  # ❌ No issue number
 git checkout -b feat/issue-42-add-feature
 ```
 
-### ❌ Mistake: Manual PR creation without automated script
+### ❌ Mistake: Manual PR creation without labels
 ```bash
-gh pr create --title "feat: add new feature (Closes #42)"  # ❌ Bypasses auto-labeling
+gh pr create --title "feat: add new feature (Closes #42)"  # ❌ No labels applied
 ```
 
-**✅ Solution:** Use the automated script
-```bash
-npm run create-pr  # ✅ Auto-applies labels and validates
+**✅ Solution:** Use GitHub MCP or the automated script
+```
+# Preferred: GitHub MCP create_pull_request with labels
+# Fallback:  npm run create-pr (auto-applies labels)
 ```
 
 ## Why This Workflow?

--- a/docs/ISSUES-SUMMARY.md
+++ b/docs/ISSUES-SUMMARY.md
@@ -55,7 +55,7 @@ The Timezone App currently has **19 open issues** organized across **2 milestone
 ```bash
 npm audit
 npm test
-gh api repos/olaoluthomas/timezone-app/code-scanning/alerts --jq '.[] | select(.state == "open")'
+# Preferred: GitHub MCP | Fallback: gh api repos/olaoluthomas/timezone-app/code-scanning/alerts --jq '.[] | select(.state == "open")'
 ```
 
 ---
@@ -79,7 +79,7 @@ gh api repos/olaoluthomas/timezone-app/code-scanning/alerts --jq '.[] | select(.
 **Verification:**
 ```bash
 npm test
-gh api repos/olaoluthomas/timezone-app/code-scanning/alerts --jq '.[] | select(.severity == "note")'
+# Preferred: GitHub MCP | Fallback: gh api repos/olaoluthomas/timezone-app/code-scanning/alerts --jq '.[] | select(.severity == "note")'
 ```
 
 ---

--- a/docs/MILESTONES.md
+++ b/docs/MILESTONES.md
@@ -366,9 +366,9 @@ Jobs:
 # Workflow triggers automatically on:
 git push origin feature-branch        # Any branch push
 git push origin pull-request          # PR to main
-gh workflow run ci.yml --ref ci/test  # Manual trigger for ci/* branches
+gh workflow run ci.yml --ref ci/test  # Manual trigger for ci/* branches (CLI only — no MCP equivalent)
 
-# View workflow status
+# View workflow status (CLI only — no MCP equivalent)
 gh run list --workflow=ci.yml
 gh run view <run-id>
 ```

--- a/docs/ci-cd/CI-TESTING.md
+++ b/docs/ci-cd/CI-TESTING.md
@@ -274,11 +274,12 @@ The CI workflow runs automatically on:
    ```
 
 2. **Pull requests to main**
-   ```bash
-   gh pr create --base main  # CI runs on PR creation
+   ```
+   # Preferred: GitHub MCP create_pull_request | Fallback: npm run create-pr
+   # CI runs automatically on PR creation
    ```
 
-3. **Manual dispatch** (for ci/* branches)
+3. **Manual dispatch** (for ci/* branches — CLI only, no MCP equivalent)
    ```bash
    gh workflow run ci.yml --ref ci/test-feature
    ```
@@ -470,8 +471,9 @@ Both should produce identical results. Local checks are faster and catch issues 
    - Fix any environment-specific issues
 
 3. **Use Draft PRs**
-   ```bash
-   gh pr create --draft  # Run CI without requesting reviews
+   ```
+   # Preferred: GitHub MCP create_pull_request (draft: true)
+   # Fallback:  gh pr create --draft
    ```
    - CI runs on draft PRs
    - Convert to ready when CI passes

--- a/docs/development/DEPENDABOT-WORKFLOW.md
+++ b/docs/development/DEPENDABOT-WORKFLOW.md
@@ -33,15 +33,11 @@
 - Use for GitHub Actions workflows targeting automated PRs
 
 **Filter Commands:**
-```bash
-# List all automated PRs
+```
+# Preferred: GitHub MCP search_pull_requests (query: "label:automated")
+# Fallback:
 gh pr list --label "automated"
-
-# List automated dependency PRs
 gh pr list --label "automated,dependencies"
-
-# Count automated PRs
-gh pr list --label "automated" --json number --jq 'length'
 ```
 
 ---
@@ -50,23 +46,19 @@ gh pr list --label "automated" --json number --jq 'length'
 
 ### Step 1: Review New PRs
 
-```bash
-# Check for new Dependabot PRs
-gh pr list --author "app/dependabot" --state open
+```
+# Preferred: GitHub MCP search_pull_requests (query: "author:app/dependabot is:open")
+# Fallback:  gh pr list --author "app/dependabot" --state open
 
-# Get PR details
-gh pr view <NUMBER> --json number,title,additions,deletions,headRefName
+# Preferred: GitHub MCP pull_request_read (method: get)
+# Fallback:  gh pr view <NUMBER> --json number,title,additions,deletions,headRefName
 ```
 
 ### Step 2: Apply Labels
 
-```bash
-# Add automated and dependencies labels
-gh pr edit <NUMBER> --add-label "automated,dependencies"
-
-# Add additional context labels as needed
-gh pr edit <NUMBER> --add-label "tests"  # if test changes
-gh pr edit <NUMBER> --add-label "code"   # if source code changes
+```
+# Preferred: GitHub MCP update_pull_request (labels: ["automated", "dependencies"])
+# Fallback:  gh pr edit <NUMBER> --add-label "automated,dependencies"
 ```
 
 ### Step 3: Local Testing
@@ -96,7 +88,7 @@ npm run test:integration
 
 | Scenario | Action | Notes |
 |----------|--------|-------|
-| ✅ All tests pass | Merge immediately | Use `gh pr merge <NUMBER> --merge --delete-branch` |
+| ✅ All tests pass | Merge immediately | GitHub MCP `merge_pull_request` or `gh pr merge <NUMBER> --merge --delete-branch` |
 | ❌ Tests fail (minor) | Fix and merge | Update tests if breaking changes are minor |
 | ❌ Tests fail (major) | Block and document | Create issue for migration work |
 | ⚠️ Major version bump | Review changelog | Check for breaking changes first |
@@ -105,9 +97,9 @@ npm run test:integration
 ### Step 5: Merge or Block
 
 **If Passing:**
-```bash
-# Merge PR
-gh pr merge <NUMBER> --merge --delete-branch
+```
+# Preferred: GitHub MCP merge_pull_request (merge_method: merge)
+# Fallback:  gh pr merge <NUMBER> --merge --delete-branch
 
 # Update local main
 git checkout main
@@ -119,12 +111,12 @@ npm test
 ```
 
 **If Blocked:**
-```bash
-# Add comment explaining why
-gh pr comment <NUMBER> --body "Blocked: <reason>. See issue #<NUMBER> for migration plan."
+```
+# Preferred: GitHub MCP add_issue_comment
+# Fallback:  gh pr comment <NUMBER> --body "Blocked: <reason>. See issue #<NUMBER> for migration plan."
 
-# Create tracking issue
-gh issue create --title "Migration: <package> to v<version>" --body "..." --label "dependencies,refactor"
+# Preferred: GitHub MCP issue_write (method: create, labels: ["dependencies", "refactor"])
+# Fallback:  gh issue create --title "Migration: <package> to v<version>" --label "dependencies,refactor"
 
 # Keep PR open for reference
 ```
@@ -198,7 +190,7 @@ gh issue create --title "Migration: <package> to v<version>" --body "..." --labe
 
 Run this checklist weekly (or when Dependabot creates new PRs):
 
-- [ ] Check for new Dependabot PRs: `gh pr list --author "app/dependabot"`
+- [ ] Check for new Dependabot PRs: GitHub MCP `search_pull_requests` (fallback: `gh pr list --author "app/dependabot"`)
 - [ ] Apply labels to new PRs: `automated`, `dependencies`
 - [ ] Review PR changes: Check `package.json` and `package-lock.json`
 - [ ] Check for major version bumps (potential breaking changes)
@@ -288,22 +280,18 @@ Run this checklist weekly (or when Dependabot creates new PRs):
 
 ### Useful Commands
 
-```bash
-# List all automated PRs
-gh pr list --label "automated"
+```
+# List automated PRs — Preferred: GitHub MCP search_pull_requests | Fallback: gh pr list --label "automated"
 
-# Test a Dependabot PR
+# Test a Dependabot PR locally
 git fetch origin <branch> && git checkout <branch>
 npm install && npm test
 
-# Merge a PR
-gh pr merge <NUMBER> --merge --delete-branch
+# Merge a PR — Preferred: GitHub MCP merge_pull_request | Fallback: gh pr merge <NUMBER> --merge --delete-branch
 
-# Block a PR with comment
-gh pr comment <NUMBER> --body "Blocked: reason here"
+# Block a PR with comment — Preferred: GitHub MCP add_issue_comment | Fallback: gh pr comment <NUMBER> --body "reason"
 
-# Create migration issue
-gh issue create --title "Migration: package to vX" --label "dependencies"
+# Create migration issue — Preferred: GitHub MCP issue_write | Fallback: gh issue create --title "Migration: package to vX" --label "dependencies"
 ```
 
 ### Status Symbols

--- a/docs/development/PR-LABELING-GUIDE.md
+++ b/docs/development/PR-LABELING-GUIDE.md
@@ -117,7 +117,16 @@ Changed files are analyzed:
 
 For PRs created outside the automation or needing corrections:
 
-### Using GitHub CLI
+### Using GitHub MCP (Preferred)
+
+```
+# Add/update labels
+update_pull_request (owner, repo, pullNumber, labels: ["label1", "label2"])
+# Or for issues:
+issue_write (method: update, labels: ["label1", "label2"])
+```
+
+### Using GitHub CLI (Fallback)
 
 ```bash
 # Add labels
@@ -125,9 +134,6 @@ gh pr edit <PR_NUMBER> --add-label "label1,label2,label3"
 
 # Remove labels
 gh pr edit <PR_NUMBER> --remove-label "label1"
-
-# Replace all labels
-gh pr edit <PR_NUMBER> --add-label "new-label" --remove-label "old-label"
 ```
 
 ### Using GitHub Web UI
@@ -234,14 +240,10 @@ Use this flowchart to determine labels:
 
 ### Tracking Label Usage
 
-```bash
-# List all PRs with specific label
+```
+# Preferred: GitHub MCP search_pull_requests or list_pull_requests
+# Fallback:
 gh pr list --label "refactor"
-
-# Count PRs by label (using jq)
-gh pr list --json labels --limit 100 | jq -r '.[].labels[].name' | sort | uniq -c | sort -rn
-
-# Recent PRs grouped by label
 gh pr list --label "enhancement" --limit 10
 ```
 
@@ -259,9 +261,9 @@ gh pr list --label "enhancement" --limit 10
 
 ### Current Available Labels
 
-```bash
-# List all labels in the repository
-gh label list
+```
+# Preferred: GitHub MCP get_label or list labels via API
+# Fallback:  gh label list
 ```
 
 **Standard Labels:**
@@ -361,30 +363,34 @@ Future integration (planned):
 
 ### Create PR with Auto-Labels
 
-```bash
-npm run create-pr
+```
+# Preferred: GitHub MCP create_pull_request (with labels)
+# Fallback:  npm run create-pr
 ```
 
 ### Manually Add Labels
 
-```bash
-gh pr edit <NUMBER> --add-label "label1,label2"
+```
+# Preferred: GitHub MCP update_pull_request (labels)
+# Fallback:  gh pr edit <NUMBER> --add-label "label1,label2"
 ```
 
 ### List PRs by Label
 
-```bash
-gh pr list --label "refactor"
+```
+# Preferred: GitHub MCP search_pull_requests (query: "label:refactor")
+# Fallback:  gh pr list --label "refactor"
 ```
 
 ### View PR Labels
 
-```bash
-gh pr view <NUMBER> --json labels
+```
+# Preferred: GitHub MCP pull_request_read (method: get)
+# Fallback:  gh pr view <NUMBER> --json labels
 ```
 
 ---
 
-**Last Review:** 2026-01-26
+**Last Review:** 2026-02-22
 **Next Review:** 2026-02-26
 **Owner:** Development Team

--- a/docs/development/WORKFLOW-IMPROVEMENTS.md
+++ b/docs/development/WORKFLOW-IMPROVEMENTS.md
@@ -70,15 +70,12 @@ docs/issue-N-short-description      # Documentation
 - `docs/WORKFLOW-IMPROVEMENTS.md` - This file
 
 **Commands:**
-```bash
-# Create issue first
-gh issue create --title "fix: Brief description" --label "bug"
-
+```
+# Create issue — Preferred: GitHub MCP issue_write | Fallback: gh issue create
 # Create branch with issue number
 git checkout -b fix/issue-N-description
 
-# Create PR with issue reference
-gh pr create --title "fix: Description (Fixes #N)"
+# Create PR — Preferred: GitHub MCP create_pull_request | Fallback: npm run create-pr
 ```
 
 ---
@@ -202,10 +199,10 @@ PR #8 automatically labeled with:
 
 **Commands:**
 
-```bash
-npm run create-pr                              # Auto-labels applied
-gh pr edit 8 --add-label "label1,label2"      # Manual label addition
-gh pr list --label "refactor"                  # Filter by label
+```
+# Preferred: GitHub MCP create_pull_request (with labels) | Fallback: npm run create-pr
+# Preferred: GitHub MCP update_pull_request (labels)      | Fallback: gh pr edit 8 --add-label "label1,label2"
+# Preferred: GitHub MCP search_pull_requests              | Fallback: gh pr list --label "refactor"
 ```
 
 ---

--- a/docs/planning/ISSUE-RECONCILIATION-2026-02-14.md
+++ b/docs/planning/ISSUE-RECONCILIATION-2026-02-14.md
@@ -124,15 +124,17 @@ All issues are organized on the [GitHub Project Board](https://github.com/users/
 
 Run these commands to verify the organization:
 
-```bash
+```
 # List all issues by milestone
-gh issue list --limit 100 --json number,title,milestone --jq 'group_by(.milestone.title) | map({milestone: .[0].milestone.title, count: length, issues: map("#\(.number)")})'
+# Preferred: GitHub MCP list_issues (per milestone)
+# Fallback:  gh issue list --limit 100 --json number,title,milestone
 
 # View project board
 open https://github.com/users/olaoluthomas/projects/3
 
 # View milestones
-gh api repos/olaoluthomas/timezone-app/milestones --jq '.[] | "\(.title): \(.open_issues) open"'
+# Preferred: GitHub MCP API
+# Fallback:  gh api repos/olaoluthomas/timezone-app/milestones
 ```
 
 ## Statistics

--- a/docs/refactoring/REFACTORING.md
+++ b/docs/refactoring/REFACTORING.md
@@ -62,8 +62,9 @@ This document serves as the index for all refactoring documentation and planning
    ```
 
 2. **View GitHub issues:**
-   ```bash
-   gh issue list --label refactor
+   ```
+   # Preferred: GitHub MCP search_issues (query: "label:refactor")
+   # Fallback:  gh issue list --label refactor
    ```
 
 3. **Pick an issue to work on:**
@@ -82,7 +83,7 @@ This document serves as the index for all refactoring documentation and planning
 
    # Push and create PR
    git push -u origin refactor/issue-37-remove-promise-wrapper
-   gh pr create --title "refactor: remove Promise.resolve() wrapper (Fixes #37)"
+   # Preferred: GitHub MCP create_pull_request | Fallback: npm run create-pr
    ```
 
 ---

--- a/docs/security/SECURITY-SCANNING-WORKFLOW.md
+++ b/docs/security/SECURITY-SCANNING-WORKFLOW.md
@@ -22,9 +22,9 @@ The timezone-app uses **Trivy container security scanning** integrated into the 
 ## Handling Security Findings
 
 ### Step 1: Review Alert
-```bash
-gh api repos/olaoluthomas/timezone-app/code-scanning/alerts \
-  --jq '.[] | {number, severity: .rule.severity, description: .rule.description}'
+```
+# Preferred: GitHub MCP (use API tools for code-scanning alerts)
+# Fallback:  gh api repos/olaoluthomas/timezone-app/code-scanning/alerts
 ```
 
 ### Step 2: Create Issue
@@ -43,7 +43,7 @@ npm audit
 npm test
 
 # Check if alert resolved
-gh api repos/olaoluthomas/timezone-app/code-scanning/alerts/<alert-id>
+# Preferred: GitHub MCP | Fallback: gh api repos/olaoluthomas/timezone-app/code-scanning/alerts/<alert-id>
 ```
 
 ### Step 4: Verify Resolution


### PR DESCRIPTION
## Summary

Standardize all workflow documentation to establish GitHub MCP tools as the preferred method for GitHub API operations, with `gh` CLI and `npm run create-pr` as fallbacks. This ensures AI assistants and developers follow a consistent pattern across all docs.

## Related Issue

Closes #122

## Impact

- 14 documentation files updated with MCP-first instructions
- Consistent guidance across CONTRIBUTING.md, WORKFLOW.md, PR-LABELING-GUIDE.md, DEPENDABOT-WORKFLOW.md, and other workflow docs
- `scripts/create-pr.sh` updated with header noting MCP as preferred method