### PR TITLE
fix(release): upgrade Node.js to 22.x for semantic-release v25

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '22.x'
           cache: 'npm'
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary

Fixes the release workflow crash caused by Node.js version incompatibility after the semantic-release v25 upgrade in PR #121. The release pipeline has been broken since that merge — no releases or CHANGELOG entries can be created until this is resolved.

## Related Issue

Closes #124

## Impact

- Release pipeline unblocked — semantic-release can run again on merge to main
- Enables CHANGELOG.md generation (re-added in #119 but never tested due to this failure)
- Processes unreleased `feat:` and `fix:` commits into the next release (v1.4.0)

---

**Note:** Keep the description concise and focused on value. Reviewers can see file changes in the diff view. Your description should answer "What problem does this solve?" and "Why does it matter?"