### PR TITLE
fix: recalculate currentTime on cache hits for accurate time display

### DIFF
--- a/src/services/geolocation.js
+++ b/src/services/geolocation.js
@@ -138,9 +138,12 @@ async function getTimezoneByIP(ip) {
     // Check cache first
     const cachedData = cache.get(cacheKey);
     if (cachedData) {
-      // Return cached data with fresh timestamp
+      // Recalculate current time from cached timezone (time changes between requests)
+      const localTime = formatTimezone(cachedData.timezone);
+
       return {
         ...cachedData,
+        currentTime: localTime,
         timestamp: new Date().toISOString(),
         cached: true,
       };

--- a/tests/unit/services/geolocation.test.js
+++ b/tests/unit/services/geolocation.test.js
@@ -133,6 +133,20 @@ describe('GeolocationService', () => {
       expect(result2.timestamp).not.toBe(result1.timestamp);
     });
 
+    test('should include currentTime on cache hits', async () => {
+      nock('https://ipapi.co').get('/8.8.8.8/json/').reply(200, mockApiResponse);
+
+      // First call - cache miss
+      const result1 = await getTimezoneByIP('8.8.8.8');
+      expect(result1.cached).toBe(false);
+      expect(result1.currentTime).toBeDefined();
+
+      // Second call - cache hit should also have currentTime
+      const result2 = await getTimezoneByIP('8.8.8.8');
+      expect(result2.cached).toBe(true);
+      expect(result2.currentTime).toBeDefined();
+    });
+
     test('should cache different IPs separately', async () => {
       nock('https://ipapi.co').get('/8.8.8.8/json/').reply(200, mockApiResponse);
 


### PR DESCRIPTION
## Summary

Fixes a bug where cached geolocation responses were missing the `currentTime` field entirely. The field was computed after cache storage but never recalculated when serving cached responses, so users receiving cache hits got no local time information. Now `currentTime` is freshly computed from the cached timezone on every request.

## Related Issue

Closes #107

## Impact

- Cached API responses now include accurate `currentTime` matching the user's timezone
- Users no longer receive incomplete responses when their data is served from cache

---

**Note:** Keep the description concise and focused on value. Reviewers can see file changes in the diff view. Your description should answer "What problem does this solve?" and "Why does it matter?"