### PR TITLE
feat: add CI/CD and infrastructure label rules to create-pr script

### DIFF
--- a/scripts/create-pr.sh
+++ b/scripts/create-pr.sh
@@ -97,9 +97,19 @@ if echo "$CHANGED_FILES" | grep -q "^docs/\|README\.md\|\.md$\|\.env\.example$";
   fi
 fi
 
-# Dependency updates
-if echo "$CHANGED_FILES" | grep -q "package\.json\|package-lock\.json"; then
+# Dependency updates (package manifests, Dockerfile base image, lock files)
+if echo "$CHANGED_FILES" | grep -q "package\.json\|package-lock\.json\|Dockerfile"; then
   LABELS+=("dependencies")
+fi
+
+# CI/CD changes (GitHub Actions workflows, scripts used by CI)
+if echo "$CHANGED_FILES" | grep -q "^\.github/workflows/\|^\.github/actions/"; then
+  LABELS+=("ci-cd")
+fi
+
+# Infrastructure changes (Docker, Compose, container config)
+if echo "$CHANGED_FILES" | grep -q "Dockerfile\|docker-compose\|\.dockerignore"; then
+  LABELS+=("infrastructure")
 fi
 
 # Middleware changes


### PR DESCRIPTION
## Summary

Expands the `create-pr.sh` auto-labeling logic to cover GitHub Actions workflows (`ci-cd`), Dockerfiles and Compose files (`infrastructure`), and Dockerfile base image changes (`dependencies`). Previously these file types received no area labels, requiring manual labeling after PR creation.

## Related Issue

Closes #130

## Impact

- PRs touching `.github/workflows/` or `.github/actions/` automatically labeled `ci-cd`
- PRs touching `Dockerfile`, `docker-compose*`, or `.dockerignore` automatically labeled `infrastructure`
- PRs touching `Dockerfile` also labeled `dependencies` (base image upgrades)
- Existing label rules unchanged