### PR TITLE
fix: handle ipapi.co 429 rate limiting with retry backoff

### DIFF
--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -84,4 +84,20 @@ module.exports = {
    * Prevents large payload attacks
    */
   REQUEST_SIZE_LIMIT: '1kb',
+
+  // ============================================
+  // Upstream API Retry Configuration
+  // ============================================
+
+  /**
+   * Maximum number of retries for upstream API rate limiting (429)
+   * Uses exponential backoff: baseDelay * 2^attempt
+   */
+  UPSTREAM_MAX_RETRIES: 3,
+
+  /**
+   * Base delay between retries in milliseconds
+   * Doubles each attempt: 1s → 2s → 4s
+   */
+  UPSTREAM_BASE_DELAY: 1000, // 1 second
 };


### PR DESCRIPTION
## Summary

Fixes production 500 errors caused by ipapi.co 429 rate-limit responses by adding retry with exponential backoff. The route handler now distinguishes rate-limit failures (503) from other errors (500), giving clients a clear signal to retry. Also disables Helmet's Cross-Origin-Opener-Policy to suppress a cosmetic browser console warning on HTTP origins.

## Related Issue

Closes #132

## Impact

- Production users see a proper 503 with `Retry-After` header instead of a misleading 500 when ipapi.co is rate-limiting
- Transient 429s are automatically retried (up to 3 times with 1s/2s/4s backoff) before surfacing to the client
- Browser console no longer shows COOP warnings on HTTP origins

---

**Note:** Keep the description concise and focused on value. Reviewers can see file changes in the diff view. Your description should answer "What problem does this solve?" and "Why does it matter?"