### PR TITLE
fix: upgrade to node:24-alpine and pin npm@11.13 in Dockerfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,13 +180,13 @@ jobs:
         run: npm audit --audit-level=moderate --omit=dev
         continue-on-error: false
 
-  # Job 3: Unit Tests (Node 20.x and 22.x)
+  # Job 3: Unit Tests (Node 20.x, 22.x, and 24.x)
   test-unit:
     name: Unit Tests (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [20.x, 22.x, 24.x]
       fail-fast: false
     needs: [validate-pr]
     if: always() && (needs.validate-pr.result == 'success' || needs.validate-pr.result == 'skipped')
@@ -213,13 +213,13 @@ jobs:
       - name: Run unit tests with coverage
         run: npm run test:unit -- --coverage
 
-  # Job 4: Integration Tests (Node 20.x and 22.x)
+  # Job 4: Integration Tests (Node 20.x, 22.x, and 24.x)
   test-integration:
     name: Integration Tests (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [20.x, 22.x, 24.x]
       fail-fast: false
     needs: [validate-pr]
     if: always() && (needs.validate-pr.result == 'success' || needs.validate-pr.result == 'skipped')
@@ -246,13 +246,13 @@ jobs:
       - name: Run integration tests
         run: npm run test:integration
 
-  # Job 5: Smoke Tests (Node 20.x and 22.x)
+  # Job 5: Smoke Tests (Node 20.x, 22.x, and 24.x)
   test-smoke:
     name: Smoke Tests (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [20.x, 22.x, 24.x]
       fail-fast: false
     needs: [validate-pr]
     if: always() && (needs.validate-pr.result == 'success' || needs.validate-pr.result == 'skipped')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22.x'
+          node-version: '24.x'
 
       - name: Cache npm dependencies
         uses: actions/cache@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Builder - Install all dependencies
-FROM node:22-alpine AS builder
+FROM node:24-alpine AS builder
 WORKDIR /app
 
 # Copy package files
@@ -12,11 +12,11 @@ RUN npm ci
 COPY . .
 
 # Stage 2: Production - Minimal runtime image
-FROM node:22-alpine AS production
+FROM node:24-alpine AS production
 WORKDIR /app
 
 # Upgrade system npm to fix Trivy-flagged CVEs in bundled deps
-RUN npm install -g npm@latest && npm cache clean --force
+RUN npm install -g npm@11.13 --no-fund --no-audit && npm cache clean --force
 
 # Install production dependencies only
 COPY package*.json ./


### PR DESCRIPTION
## Summary

Fixes the failing "build and push container" workflow by upgrading the base image to `node:24-alpine` (latest LTS) and replacing the unpinned `npm@latest` upgrade with `npm@11.13`. Using `@latest` is a moving target that broke CI without any code changes; pinning to a specific version makes builds reproducible and prevents future silent breakage.

## Impact

- Unblocks the container build and push workflow
- Upgrades Node.js runtime from 22 → 24 (latest LTS, supported until April 2027)
- Pins npm to 11.13 (stable, CVE-patched) instead of `@latest`

Closes #154

## Test plan

- [x] Trigger "build and push container" workflow manually via Actions → workflow_dispatch
- [x] Confirm Docker build completes past the `npm install -g npm@11.13` step without error
- [x] Confirm image is pushed to the registry successfully