### PR TITLE
ci: sequence Release after CI on the merge commit and bump on chore(deps)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,37 @@ jobs:
       issues: write
       pull-requests: write
     steps:
+      - name: Wait for CI to succeed on this commit
+        if: github.event_name != 'workflow_dispatch'
+        timeout-minutes: 15
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SHA: ${{ github.sha }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          while :; do
+            RUN=$(gh run list --repo "$REPO" --commit "$SHA" --workflow CI --limit 1 \
+              --json status,conclusion --jq '.[0]')
+            if [ -z "$RUN" ] || [ "$RUN" = "null" ]; then
+              echo "No CI run registered yet for $SHA; waiting..."
+              sleep 20
+              continue
+            fi
+            STATUS=$(echo "$RUN" | jq -r .status)
+            if [ "$STATUS" = "completed" ]; then
+              break
+            fi
+            echo "CI status: $STATUS; waiting..."
+            sleep 20
+          done
+          CONCLUSION=$(echo "$RUN" | jq -r .conclusion)
+          echo "CI conclusion: $CONCLUSION"
+          if [ "$CONCLUSION" != "success" ]; then
+            echo "CI did not succeed on $SHA. Aborting release."
+            exit 1
+          fi
+
       - name: Checkout code
         uses: actions/checkout@v4
         with:

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -11,6 +11,7 @@
           { "type": "fix", "release": "patch" },
           { "type": "perf", "release": "patch" },
           { "type": "refactor", "release": "patch" },
+          { "type": "chore", "scope": "deps", "release": "patch" },
           { "breaking": true, "release": "major" }
         ]
       }


### PR DESCRIPTION
## Summary

Adds an explicit "Wait for CI" step at the start of the `release` job that polls for the CI workflow run on the same commit SHA and aborts if CI did not succeed. This sequences semantic-release after CI on the post-merge commit, closing a gap where branch protection only enforces CI on the PR head, not the merge commit. Also adds a `chore(deps)` patch release rule so production dependency bumps from Dependabot increment the version (`chore(deps-dev)` is intentionally excluded).

## Impact

- Eliminates the race where Release and CI run in parallel on a push to `main`
- Production dependency updates now produce versioned releases automatically
- `release.yml` triggers (`push` + `paths-ignore`, `workflow_dispatch`) are unchanged
- Manual `workflow_dispatch` releases still bypass the wait step (for hotfixes)

Closes #156

## Test plan

- [ ] After merge, push a benign commit to `main` and confirm Release waits, then proceeds only after CI succeeds
- [ ] Simulate a CI failure on a follow-up branch and confirm Release aborts with `CI did not succeed on $SHA`
- [ ] Push a docs-only change and confirm Release is skipped by `paths-ignore` (no wait happens)
- [ ] Trigger Release manually via `workflow_dispatch` and confirm the wait step is skipped
- [ ] Merge a synthetic `chore(deps): bump <pkg>` commit and confirm a patch version is released
- [ ] Merge a synthetic `chore(deps-dev): bump <pkg>` commit and confirm no release is issued