### PR TITLE
ci: scan main image in container.yml to refresh code scanning alerts

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -5,8 +5,36 @@ on:
     types: [published]
 
   push:
+    branches:
+      - main
     tags:
       - 'v*'
+    paths-ignore:
+      # Documentation
+      - '**.md'
+      - 'docs/**'
+      - '.github/pull_request_template.md'
+
+      # License and legal
+      - 'LICENSE'
+      - 'AUTHORS'
+      - 'NOTICE'
+
+      # Git configuration
+      - '.gitignore'
+      - '.gitattributes'
+
+      # Code quality configs (don't affect versioning)
+      - '.eslintrc*'
+      - 'eslint.config.*'
+      - '.prettierrc*'
+      - '.prettierignore'
+      - 'commitlint.config.*'
+      - '.editorconfig'
+
+      # Editor directories
+      - '.vscode/**'
+      - '.idea/**'
 
   workflow_dispatch:
 
@@ -15,8 +43,46 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
+  scan-main:
+    name: Scan main image (no push)
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image (load locally, no push)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: false
+          load: true
+          tags: timezone-app:scan
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Run Trivy security scan
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: timezone-app:scan
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+
+      - name: Upload Trivy results to GitHub Security
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: 'trivy-results.sarif'
+          category: trivy-main
+
   build-and-push:
     name: Build and Push Container Image
+    if: github.event_name == 'release' || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

Refreshes stale Trivy code-scanning alerts on `refs/heads/main` by re-adding a security scan on push to main. The existing release/tag-driven build-and-push to GHCR is unchanged. No registry push is added on commits to main — only a local image build for scanning.

## Why

GitHub Code Scanning shows 9 open Trivy alerts on `refs/heads/main`, all stuck at commit `d90c1b1` from 2026-02-22. PR #119 removed `branches: - main` from `container.yml`'s push trigger, so every Trivy SARIF upload since has been tagged `refs/tags/v*` — main's alert state has been frozen for 2+ months even though current images scan 0/0.

## What

`.github/workflows/container.yml`:
- Trigger: re-add `push: branches: [main]` with the `paths-ignore` list mirroring `release.yml`
- New `scan-main` job (gated on push to main): build with `load: true, push: false`, run Trivy, upload SARIF with `category: trivy-main`
- Existing `build-and-push` job: add `if:` gate so it only fires on release / tag push / workflow_dispatch (no behavior change otherwise)

Closes #160

Follow-up #159 tracks gating releases on Trivy findings — out of scope here.