### PR TITLE
ci: chain container.yml off Release workflow_run instead of push to main

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -4,37 +4,10 @@ on:
   release:
     types: [published]
 
-  push:
-    branches:
-      - main
-    tags:
-      - 'v*'
-    paths-ignore:
-      # Documentation
-      - '**.md'
-      - 'docs/**'
-      - '.github/pull_request_template.md'
-
-      # License and legal
-      - 'LICENSE'
-      - 'AUTHORS'
-      - 'NOTICE'
-
-      # Git configuration
-      - '.gitignore'
-      - '.gitattributes'
-
-      # Code quality configs (don't affect versioning)
-      - '.eslintrc*'
-      - 'eslint.config.*'
-      - '.prettierrc*'
-      - '.prettierignore'
-      - 'commitlint.config.*'
-      - '.editorconfig'
-
-      # Editor directories
-      - '.vscode/**'
-      - '.idea/**'
+  workflow_run:
+    workflows: ["Release"]
+    types: [completed]
+    branches: [main]
 
   workflow_dispatch:
 
@@ -45,7 +18,9 @@ env:
 jobs:
   scan-main:
     name: Scan main image (no push)
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: |
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
+      github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -82,7 +57,7 @@ jobs:
 
   build-and-push:
     name: Build and Push Container Image
-    if: github.event_name == 'release' || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

Reorders the CI/CD pipeline so the `Container Build & Push` workflow runs strictly after `Release` succeeds, rather than fanning out in parallel with CI/Release on every push to main. Trivy scans of main and release builds now both chain off `Release` instead of raw push events.

## Why

PR #161 wired `scan-main` to `push: branches: [main]`, so every code push to main produced three parallel workflow runs against the same SHA: **CI**, **Release** (already CI-gated), and **Container Build & Push (`scan-main`)**. The container scan could race ahead of CI/Release, run on a SHA that ultimately failed CI, or precede the post-release `chore(release)` commit. The intended order is `push → CI → Release → Container`.

## What

`.github/workflows/container.yml`:
- **Trigger**: drop `push: branches: [main], tags: ['v*']` and the `paths-ignore` block; add `workflow_run` on the `Release` workflow completing (branches: main). Docs-only commits are filtered upstream by `release.yml`'s own `paths-ignore`.
- **`scan-main`**: gate on `(workflow_run && conclusion == 'success') || workflow_dispatch`. Fires only after Release succeeds, refreshing `refs/heads/main` Trivy alerts against the post-release main HEAD.
- **`build-and-push`**: gate on `release || workflow_dispatch`. The unreachable `push && refs/tags/` clause is removed since the push-tag trigger is gone.

Closes #162

Follow-up to #161 / #160. Trivy gating tracked in #159.