### PR TITLE
ci: raise coverageThreshold to 80% for branches and functions

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -2,8 +2,8 @@ module.exports = {
   testEnvironment: 'node',
   coverageThreshold: {
     global: {
-      branches: 70,
-      functions: 75,
+      branches: 80,
+      functions: 80,
       lines: 80,
       statements: 80
     }


### PR DESCRIPTION
## Summary

Raises `branches` (70→80) and `functions` (75→80) in `jest.config.cjs` to align all four coverage metrics at the 80% floor required by #158.

The existing test suite already achieves 95%+ branches and 97%+ functions — 15–18 pp above the new threshold — so no test changes are needed.

## Impact

- Coverage gate is now consistent across all four dimensions (branches, functions, lines, statements: all 80%)
- Enforcement was already wired in both local pre-push (`run-ci-tests.sh` steps 5 and 8) and CI (`test-unit` and `coverage` jobs); no workflow changes needed

Closes #158