### PR TITLE
refactor(tests): extract nock helpers to eliminate duplicate setup

### DIFF
--- a/tests/helpers/nock-mocks.js
+++ b/tests/helpers/nock-mocks.js
@@ -1,0 +1,89 @@
+const nock = require('nock');
+
+const IPAPI_BASE = 'https://ipapi.co';
+
+const MOCK_RESPONSES = {
+  SUCCESS: {
+    ip: '8.8.8.8',
+    city: 'Mountain View',
+    region: 'California',
+    country_name: 'United States',
+    country_code: 'US',
+    latitude: 37.4056,
+    longitude: -122.0775,
+    timezone: 'America/Los_Angeles',
+    utc_offset: '-0800',
+  },
+  SECURITY: {
+    ip: '203.0.113.1',
+    city: 'Test City',
+    region: 'Test Region',
+    country_name: 'Test Country',
+    country_code: 'TC',
+    latitude: 40.7128,
+    longitude: -74.006,
+    timezone: 'America/New_York',
+    utc_offset: '-0500',
+  },
+  MINIMAL: { ip: '8.8.8.8' },
+  EMPTY: {},
+};
+
+// options: { key, times, delay, delayConnection, persist }
+function mockGeolocationSuccess(ip, response = MOCK_RESPONSES.SUCCESS, options = {}) {
+  const path = ip ? `/${ip}/json/` : '/json/';
+  const qs = options.key ? `?key=${options.key}` : '';
+  let interceptor = nock(IPAPI_BASE).get(`${path}${qs}`);
+  if (options.times) interceptor = interceptor.times(options.times);
+  if (options.delayConnection) interceptor = interceptor.delayConnection(options.delayConnection);
+  if (options.delay) interceptor = interceptor.delay(options.delay);
+  const scope = interceptor.reply(200, response);
+  if (options.persist) scope.persist();
+  return scope;
+}
+
+function mockGeolocationError(ip, statusCode = 500, body = {}) {
+  const path = ip ? `/${ip}/json/` : '/json/';
+  return nock(IPAPI_BASE).get(path).reply(statusCode, body);
+}
+
+// options: { times, retryAfter, key }
+function mockGeolocationRateLimit(ip, options = {}) {
+  const path = ip ? `/${ip}/json/` : '/json/';
+  const qs = options.key ? `?key=${options.key}` : '';
+  const headers =
+    options.retryAfter !== undefined ? { 'Retry-After': String(options.retryAfter) } : {};
+  let interceptor = nock(IPAPI_BASE).get(`${path}${qs}`);
+  if (options.times) interceptor = interceptor.times(options.times);
+  return interceptor.reply(429, { error: 'Rate limited' }, headers);
+}
+
+// error: string error code or Error/object passed directly to replyWithError
+function mockGeolocationNetworkError(ip, error) {
+  const path = ip ? `/${ip}/json/` : '/json/';
+  const errorArg = typeof error === 'string' ? { code: error } : error;
+  return nock(IPAPI_BASE).get(path).replyWithError(errorArg);
+}
+
+// Regex path match used by security tests; persisted by default
+function mockGeolocationRegex(response = MOCK_RESPONSES.SECURITY, persist = true) {
+  const scope = nock(IPAPI_BASE)
+    .get(/\/.*\/json\//)
+    .reply(200, response);
+  if (persist) scope.persist();
+  return scope;
+}
+
+function cleanMocks() {
+  nock.cleanAll();
+}
+
+module.exports = {
+  MOCK_RESPONSES,
+  mockGeolocationSuccess,
+  mockGeolocationError,
+  mockGeolocationRateLimit,
+  mockGeolocationNetworkError,
+  mockGeolocationRegex,
+  cleanMocks,
+};

--- a/tests/helpers/test-setup.js
+++ b/tests/helpers/test-setup.js
@@ -1,0 +1,22 @@
+const nock = require('nock');
+const { cleanMocks } = require('./nock-mocks');
+
+function setupGeolocationTests(clearCacheFn) {
+  beforeEach(() => {
+    clearCacheFn();
+    cleanMocks();
+  });
+  afterAll(() => nock.restore());
+}
+
+function setupIntegrationTests() {
+  beforeEach(() => cleanMocks());
+  afterAll(() => nock.restore());
+}
+
+// Security tests use afterEach (not afterAll) because mocks are re-registered each beforeEach
+function setupSecurityTests() {
+  afterEach(() => cleanMocks());
+}
+
+module.exports = { setupGeolocationTests, setupIntegrationTests, setupSecurityTests };

--- a/tests/integration/api/health.test.js
+++ b/tests/integration/api/health.test.js
@@ -1,15 +1,15 @@
 const request = require('supertest');
-const nock = require('nock');
 const app = require('../../../src/app');
+const {
+  MOCK_RESPONSES,
+  mockGeolocationSuccess,
+  mockGeolocationError,
+  mockGeolocationNetworkError,
+} = require('../../helpers/nock-mocks');
+const { setupIntegrationTests } = require('../../helpers/test-setup');
 
 describe('Health Check Endpoints', () => {
-  beforeEach(() => {
-    nock.cleanAll();
-  });
-
-  afterAll(() => {
-    nock.restore();
-  });
+  setupIntegrationTests();
 
   describe('GET /health', () => {
     test('should return 200 with health status', async () => {
@@ -52,7 +52,7 @@ describe('Health Check Endpoints', () => {
 
   describe('GET /health/ready', () => {
     test('should return 200 when all dependencies healthy', async () => {
-      nock('https://ipapi.co').get('/json/').reply(200, { ip: '8.8.8.8' });
+      mockGeolocationSuccess(null, MOCK_RESPONSES.MINIMAL);
 
       const response = await request(app).get('/health/ready');
 
@@ -61,7 +61,7 @@ describe('Health Check Endpoints', () => {
     });
 
     test('should return 503 when API is down', async () => {
-      nock('https://ipapi.co').get('/json/').reply(500, {});
+      mockGeolocationError(null, 500);
 
       const response = await request(app).get('/health/ready');
 
@@ -70,7 +70,7 @@ describe('Health Check Endpoints', () => {
     });
 
     test('should include detailed check results', async () => {
-      nock('https://ipapi.co').get('/json/').reply(200, {});
+      mockGeolocationSuccess(null, MOCK_RESPONSES.EMPTY);
 
       const response = await request(app).get('/health/ready');
 
@@ -80,7 +80,7 @@ describe('Health Check Endpoints', () => {
     });
 
     test('should include response time metrics', async () => {
-      nock('https://ipapi.co').get('/json/').reply(200, {});
+      mockGeolocationSuccess(null, MOCK_RESPONSES.EMPTY);
 
       const response = await request(app).get('/health/ready');
 
@@ -90,7 +90,7 @@ describe('Health Check Endpoints', () => {
     });
 
     test('should handle API timeout gracefully', async () => {
-      nock('https://ipapi.co').get('/json/').delayConnection(3000).reply(200, {});
+      mockGeolocationSuccess(null, MOCK_RESPONSES.EMPTY, { delayConnection: 3000 });
 
       const response = await request(app).get('/health/ready');
 
@@ -99,7 +99,7 @@ describe('Health Check Endpoints', () => {
     });
 
     test('should handle network errors', async () => {
-      nock('https://ipapi.co').get('/json/').replyWithError({ code: 'ENOTFOUND' });
+      mockGeolocationNetworkError(null, 'ENOTFOUND');
 
       const response = await request(app).get('/health/ready');
 
@@ -108,7 +108,7 @@ describe('Health Check Endpoints', () => {
     });
 
     test('should complete within acceptable time', async () => {
-      nock('https://ipapi.co').get('/json/').reply(200, {});
+      mockGeolocationSuccess(null, MOCK_RESPONSES.EMPTY);
 
       const startTime = Date.now();
       await request(app).get('/health/ready');
@@ -118,7 +118,7 @@ describe('Health Check Endpoints', () => {
     });
 
     test('should include timestamp and uptime', async () => {
-      nock('https://ipapi.co').get('/json/').reply(200, {});
+      mockGeolocationSuccess(null, MOCK_RESPONSES.EMPTY);
 
       const response = await request(app).get('/health/ready');
 
@@ -128,7 +128,7 @@ describe('Health Check Endpoints', () => {
     });
 
     test('should show cache statistics when healthy', async () => {
-      nock('https://ipapi.co').get('/json/').reply(200, {});
+      mockGeolocationSuccess(null, MOCK_RESPONSES.EMPTY);
 
       const response = await request(app).get('/health/ready');
 
@@ -137,7 +137,7 @@ describe('Health Check Endpoints', () => {
     });
 
     test('should handle multiple simultaneous requests', async () => {
-      nock('https://ipapi.co').get('/json/').times(3).reply(200, {});
+      mockGeolocationSuccess(null, MOCK_RESPONSES.EMPTY, { times: 3 });
 
       const requests = [
         request(app).get('/health/ready'),
@@ -157,7 +157,7 @@ describe('Health Check Endpoints', () => {
   describe('Health Endpoints Error Handling', () => {
     test('/health should never return error even if other issues exist', async () => {
       // Simulate some external issue
-      nock('https://ipapi.co').get('/json/').reply(500, {});
+      mockGeolocationError(null, 500);
 
       const response = await request(app).get('/health');
 
@@ -168,7 +168,7 @@ describe('Health Check Endpoints', () => {
 
     test('/health/ready should catch unexpected errors', async () => {
       // Don't mock anything - let it fail naturally
-      nock('https://ipapi.co').get('/json/').replyWithError(new Error('Catastrophic failure'));
+      mockGeolocationNetworkError(null, new Error('Catastrophic failure'));
 
       const response = await request(app).get('/health/ready');
 

--- a/tests/integration/security/security.test.js
+++ b/tests/integration/security/security.test.js
@@ -1,44 +1,20 @@
 const request = require('supertest');
-const nock = require('nock');
 const app = require('../../../src/app');
+const {
+  MOCK_RESPONSES,
+  mockGeolocationRegex,
+  mockGeolocationSuccess,
+} = require('../../helpers/nock-mocks');
+const { setupSecurityTests } = require('../../helpers/test-setup');
 
 describe('Security Middleware Integration', () => {
   // Mock the external geolocation API for all tests
   beforeEach(() => {
-    nock('https://ipapi.co')
-      .get(/\/.*\/json\//)
-      .reply(200, {
-        ip: '203.0.113.1',
-        city: 'Test City',
-        region: 'Test Region',
-        country_name: 'Test Country',
-        country_code: 'TC',
-        latitude: 40.7128,
-        longitude: -74.006,
-        timezone: 'America/New_York',
-        utc_offset: '-0500',
-      })
-      .persist();
-
-    nock('https://ipapi.co')
-      .get('/json/')
-      .reply(200, {
-        ip: '203.0.113.1',
-        city: 'Test City',
-        region: 'Test Region',
-        country_name: 'Test Country',
-        country_code: 'TC',
-        latitude: 40.7128,
-        longitude: -74.006,
-        timezone: 'America/New_York',
-        utc_offset: '-0500',
-      })
-      .persist();
+    mockGeolocationRegex();
+    mockGeolocationSuccess(null, MOCK_RESPONSES.SECURITY, { persist: true });
   });
 
-  afterEach(() => {
-    nock.cleanAll();
-  });
+  setupSecurityTests();
 
   describe('Security Headers', () => {
     it('should include X-Content-Type-Options header', async () => {

--- a/tests/unit/services/geolocation.test.js
+++ b/tests/unit/services/geolocation.test.js
@@ -1,33 +1,20 @@
 const nock = require('nock');
 const { getTimezoneByIP, getCacheStats, clearCache } = require('../../../src/services/geolocation');
+const {
+  MOCK_RESPONSES,
+  mockGeolocationSuccess,
+  mockGeolocationError,
+  mockGeolocationRateLimit,
+  mockGeolocationNetworkError,
+} = require('../../helpers/nock-mocks');
+const { setupGeolocationTests } = require('../../helpers/test-setup');
 
 describe('GeolocationService', () => {
-  const mockApiResponse = {
-    ip: '8.8.8.8',
-    city: 'Mountain View',
-    region: 'California',
-    country_name: 'United States',
-    country_code: 'US',
-    latitude: 37.4056,
-    longitude: -122.0775,
-    timezone: 'America/Los_Angeles',
-    utc_offset: '-0800',
-  };
-
-  beforeEach(() => {
-    // Clear cache before each test
-    clearCache();
-    // Clean all nock interceptors
-    nock.cleanAll();
-  });
-
-  afterAll(() => {
-    nock.restore();
-  });
+  setupGeolocationTests(clearCache);
 
   describe('getTimezoneByIP', () => {
     test('should fetch timezone data for valid IP', async () => {
-      nock('https://ipapi.co').get('/8.8.8.8/json/').reply(200, mockApiResponse);
+      mockGeolocationSuccess('8.8.8.8');
 
       const result = await getTimezoneByIP('8.8.8.8');
 
@@ -42,7 +29,7 @@ describe('GeolocationService', () => {
     });
 
     test('should handle localhost IP (127.0.0.1)', async () => {
-      nock('https://ipapi.co').get('/json/').reply(200, mockApiResponse);
+      mockGeolocationSuccess(null);
 
       const result = await getTimezoneByIP('127.0.0.1');
 
@@ -51,7 +38,7 @@ describe('GeolocationService', () => {
     });
 
     test('should handle IPv6 localhost (::1)', async () => {
-      nock('https://ipapi.co').get('/json/').reply(200, mockApiResponse);
+      mockGeolocationSuccess(null);
 
       const result = await getTimezoneByIP('::1');
 
@@ -60,7 +47,7 @@ describe('GeolocationService', () => {
     });
 
     test('should handle ::ffff:127.x.x.x format', async () => {
-      nock('https://ipapi.co').get('/json/').reply(200, mockApiResponse);
+      mockGeolocationSuccess(null);
 
       const result = await getTimezoneByIP('::ffff:127.0.0.1');
 
@@ -69,7 +56,7 @@ describe('GeolocationService', () => {
     });
 
     test('should throw error on API failure', async () => {
-      nock('https://ipapi.co').get('/8.8.8.8/json/').reply(500, { error: 'Internal Server Error' });
+      mockGeolocationError('8.8.8.8', 500, { error: 'Internal Server Error' });
 
       await expect(getTimezoneByIP('8.8.8.8')).rejects.toThrow(
         'Unable to determine location from IP address'
@@ -77,7 +64,7 @@ describe('GeolocationService', () => {
     });
 
     test('should throw error on network timeout', async () => {
-      nock('https://ipapi.co').get('/8.8.8.8/json/').replyWithError({ code: 'ETIMEDOUT' });
+      mockGeolocationNetworkError('8.8.8.8', 'ETIMEDOUT');
 
       await expect(getTimezoneByIP('8.8.8.8')).rejects.toThrow(
         'Unable to determine location from IP address'
@@ -86,7 +73,7 @@ describe('GeolocationService', () => {
 
     test('should not retry on non-429 errors (e.g., 500)', async () => {
       // Only one nock interceptor — if a retry happened, nock would throw
-      nock('https://ipapi.co').get('/8.8.8.8/json/').reply(500, { error: 'Server Error' });
+      mockGeolocationError('8.8.8.8', 500, { error: 'Server Error' });
 
       await expect(getTimezoneByIP('8.8.8.8')).rejects.toThrow(
         'Unable to determine location from IP address'
@@ -94,7 +81,7 @@ describe('GeolocationService', () => {
     });
 
     test('should include all required fields in response', async () => {
-      nock('https://ipapi.co').get('/8.8.8.8/json/').reply(200, mockApiResponse);
+      mockGeolocationSuccess('8.8.8.8');
 
       const result = await getTimezoneByIP('8.8.8.8');
 
@@ -115,7 +102,7 @@ describe('GeolocationService', () => {
 
   describe('caching behavior', () => {
     test('should cache IP lookup results', async () => {
-      nock('https://ipapi.co').get('/8.8.8.8/json/').reply(200, mockApiResponse);
+      mockGeolocationSuccess('8.8.8.8');
 
       // First call - should hit API
       const result1 = await getTimezoneByIP('8.8.8.8');
@@ -129,7 +116,7 @@ describe('GeolocationService', () => {
     });
 
     test('should have different timestamps for cached calls', async () => {
-      nock('https://ipapi.co').get('/8.8.8.8/json/').reply(200, mockApiResponse);
+      mockGeolocationSuccess('8.8.8.8');
 
       const result1 = await getTimezoneByIP('8.8.8.8');
 
@@ -143,7 +130,7 @@ describe('GeolocationService', () => {
     });
 
     test('should include currentTime on cache hits', async () => {
-      nock('https://ipapi.co').get('/8.8.8.8/json/').reply(200, mockApiResponse);
+      mockGeolocationSuccess('8.8.8.8');
 
       // First call - cache miss
       const result1 = await getTimezoneByIP('8.8.8.8');
@@ -157,15 +144,12 @@ describe('GeolocationService', () => {
     });
 
     test('should cache different IPs separately', async () => {
-      nock('https://ipapi.co').get('/8.8.8.8/json/').reply(200, mockApiResponse);
-
-      nock('https://ipapi.co')
-        .get('/1.1.1.1/json/')
-        .reply(200, {
-          ...mockApiResponse,
-          ip: '1.1.1.1',
-          city: 'Los Angeles',
-        });
+      mockGeolocationSuccess('8.8.8.8');
+      mockGeolocationSuccess('1.1.1.1', {
+        ...MOCK_RESPONSES.SUCCESS,
+        ip: '1.1.1.1',
+        city: 'Los Angeles',
+      });
 
       const result1 = await getTimezoneByIP('8.8.8.8');
       const result2 = await getTimezoneByIP('1.1.1.1');
@@ -186,7 +170,7 @@ describe('GeolocationService', () => {
 
   describe('getCacheStats', () => {
     test('should return cache statistics', async () => {
-      nock('https://ipapi.co').get('/8.8.8.8/json/').reply(200, mockApiResponse);
+      mockGeolocationSuccess('8.8.8.8');
 
       await getTimezoneByIP('8.8.8.8');
       await getTimezoneByIP('8.8.8.8'); // cached
@@ -203,7 +187,7 @@ describe('GeolocationService', () => {
 
   describe('clearCache', () => {
     test('should clear cached entries', async () => {
-      nock('https://ipapi.co').get('/8.8.8.8/json/').twice().reply(200, mockApiResponse);
+      mockGeolocationSuccess('8.8.8.8', MOCK_RESPONSES.SUCCESS, { times: 2 });
 
       // First call
       await getTimezoneByIP('8.8.8.8');
@@ -223,7 +207,7 @@ describe('GeolocationService', () => {
 
   describe('IP normalization', () => {
     test('should handle IPv6-mapped IPv4 localhost', async () => {
-      nock('https://ipapi.co').get('/json/').reply(200, mockApiResponse);
+      mockGeolocationSuccess(null);
 
       const result = await getTimezoneByIP('::ffff:127.0.0.1');
       expect(result).toHaveProperty('timezone');
@@ -231,7 +215,7 @@ describe('GeolocationService', () => {
     });
 
     test('should handle IPv6-mapped private IPs (192.168.x.x)', async () => {
-      nock('https://ipapi.co').get('/json/').reply(200, mockApiResponse);
+      mockGeolocationSuccess(null);
 
       const result = await getTimezoneByIP('::ffff:192.168.1.1');
       expect(result).toHaveProperty('timezone');
@@ -239,7 +223,7 @@ describe('GeolocationService', () => {
     });
 
     test('should handle IPv6-mapped private IPs (10.x.x.x)', async () => {
-      nock('https://ipapi.co').get('/json/').reply(200, mockApiResponse);
+      mockGeolocationSuccess(null);
 
       const result = await getTimezoneByIP('::ffff:10.0.0.1');
       expect(result).toHaveProperty('timezone');
@@ -247,7 +231,7 @@ describe('GeolocationService', () => {
     });
 
     test('should handle IPv6-mapped private IPs (172.16-31.x.x)', async () => {
-      nock('https://ipapi.co').get('/json/').reply(200, mockApiResponse);
+      mockGeolocationSuccess(null);
 
       const result = await getTimezoneByIP('::ffff:172.16.0.1');
       expect(result).toHaveProperty('timezone');
@@ -255,7 +239,7 @@ describe('GeolocationService', () => {
     });
 
     test('should handle pure IPv6 localhost', async () => {
-      nock('https://ipapi.co').get('/json/').reply(200, mockApiResponse);
+      mockGeolocationSuccess(null);
 
       const result = await getTimezoneByIP('::1');
       expect(result).toHaveProperty('timezone');
@@ -263,7 +247,7 @@ describe('GeolocationService', () => {
     });
 
     test('should handle pure IPv4 localhost', async () => {
-      nock('https://ipapi.co').get('/json/').reply(200, mockApiResponse);
+      mockGeolocationSuccess(null);
 
       const result = await getTimezoneByIP('127.0.0.1');
       expect(result).toHaveProperty('timezone');
@@ -271,7 +255,7 @@ describe('GeolocationService', () => {
     });
 
     test('should handle IPv6-mapped public IPs', async () => {
-      nock('https://ipapi.co').get('/8.8.8.8/json/').reply(200, mockApiResponse);
+      mockGeolocationSuccess('8.8.8.8');
 
       const result = await getTimezoneByIP('::ffff:8.8.8.8');
       expect(result).toHaveProperty('timezone');
@@ -281,7 +265,7 @@ describe('GeolocationService', () => {
     test('should normalize and use IPv4 for IPv6-mapped public IP', async () => {
       // When we pass ::ffff:8.8.8.8, it should normalize to 8.8.8.8
       // and make the API call with the pure IPv4 address
-      nock('https://ipapi.co').get('/8.8.8.8/json/').reply(200, mockApiResponse);
+      mockGeolocationSuccess('8.8.8.8');
 
       const result = await getTimezoneByIP('::ffff:8.8.8.8');
       expect(result).toHaveProperty('ip', '8.8.8.8');
@@ -307,9 +291,8 @@ describe('GeolocationService', () => {
     });
 
     test('should retry on 429 and succeed on subsequent attempt', async () => {
-      nock('https://ipapi.co').get('/8.8.8.8/json/').reply(429, { error: 'Rate limited' });
-
-      nock('https://ipapi.co').get('/8.8.8.8/json/').reply(200, mockApiResponse);
+      mockGeolocationRateLimit('8.8.8.8');
+      mockGeolocationSuccess('8.8.8.8');
 
       const result = await getTimezoneByIP('8.8.8.8');
 
@@ -320,7 +303,7 @@ describe('GeolocationService', () => {
 
     test('should retry up to max retries on persistent 429', async () => {
       // 1 initial + 3 retries = 4 total requests
-      nock('https://ipapi.co').get('/8.8.8.8/json/').times(4).reply(429, { error: 'Rate limited' });
+      mockGeolocationRateLimit('8.8.8.8', { times: 4 });
 
       await expect(getTimezoneByIP('8.8.8.8')).rejects.toThrow(
         'Upstream geolocation API rate limited'
@@ -328,7 +311,7 @@ describe('GeolocationService', () => {
     });
 
     test('should set rateLimited flag on persistent 429', async () => {
-      nock('https://ipapi.co').get('/8.8.8.8/json/').times(4).reply(429, { error: 'Rate limited' });
+      mockGeolocationRateLimit('8.8.8.8', { times: 4 });
 
       await expect(getTimezoneByIP('8.8.8.8')).rejects.toMatchObject({
         rateLimited: true,
@@ -338,11 +321,8 @@ describe('GeolocationService', () => {
     test('should respect Retry-After header', async () => {
       CONSTANTS.UPSTREAM_BASE_DELAY = 10;
 
-      nock('https://ipapi.co')
-        .get('/8.8.8.8/json/')
-        .reply(429, { error: 'Rate limited' }, { 'Retry-After': '1' });
-
-      nock('https://ipapi.co').get('/8.8.8.8/json/').reply(200, mockApiResponse);
+      mockGeolocationRateLimit('8.8.8.8', { retryAfter: 1 });
+      mockGeolocationSuccess('8.8.8.8');
 
       const result = await getTimezoneByIP('8.8.8.8');
       expect(result).toHaveProperty('ip', '8.8.8.8');
@@ -351,12 +331,6 @@ describe('GeolocationService', () => {
 
   describe('development fallback', () => {
     const originalEnv = process.env.NODE_ENV;
-
-    beforeEach(() => {
-      // Clear cache using the original module
-      clearCache();
-      nock.cleanAll();
-    });
 
     afterEach(() => {
       process.env.NODE_ENV = originalEnv;
@@ -370,7 +344,7 @@ describe('GeolocationService', () => {
       jest.resetModules();
       const { getTimezoneByIP } = require('../../../src/services/geolocation');
 
-      nock('https://ipapi.co').get('/json/').reply(500, { error: 'Server error' });
+      mockGeolocationError(null, 500, { error: 'Server error' });
 
       const result = await getTimezoneByIP('127.0.0.1');
 
@@ -387,7 +361,7 @@ describe('GeolocationService', () => {
       jest.resetModules();
       const { getTimezoneByIP } = require('../../../src/services/geolocation');
 
-      nock('https://ipapi.co').get('/json/').reply(500, { error: 'Server error' });
+      mockGeolocationError(null, 500, { error: 'Server error' });
 
       const result = await getTimezoneByIP('192.168.1.1');
 
@@ -401,7 +375,7 @@ describe('GeolocationService', () => {
       jest.resetModules();
       const { getTimezoneByIP } = require('../../../src/services/geolocation');
 
-      nock('https://ipapi.co').get('/8.8.8.8/json/').reply(500);
+      mockGeolocationError('8.8.8.8', 500);
 
       const result = await getTimezoneByIP('8.8.8.8');
 
@@ -415,7 +389,7 @@ describe('GeolocationService', () => {
       jest.resetModules();
       const { getTimezoneByIP } = require('../../../src/services/geolocation');
 
-      nock('https://ipapi.co').get('/json/').reply(500);
+      mockGeolocationError(null, 500);
 
       await expect(getTimezoneByIP('127.0.0.1')).rejects.toThrow(
         'Unable to determine location from IP address'
@@ -428,7 +402,7 @@ describe('GeolocationService', () => {
       jest.resetModules();
       const { getTimezoneByIP } = require('../../../src/services/geolocation');
 
-      nock('https://ipapi.co').get('/json/').reply(500);
+      mockGeolocationError(null, 500);
 
       await expect(getTimezoneByIP('127.0.0.1')).rejects.toThrow(
         'Unable to determine location from IP address'
@@ -441,7 +415,7 @@ describe('GeolocationService', () => {
       jest.resetModules();
       const { getTimezoneByIP } = require('../../../src/services/geolocation');
 
-      nock('https://ipapi.co').get('/json/').reply(500);
+      mockGeolocationError(null, 500);
 
       await expect(getTimezoneByIP('127.0.0.1')).rejects.toThrow(
         'Unable to determine location from IP address'
@@ -454,7 +428,7 @@ describe('GeolocationService', () => {
       jest.resetModules();
       const { getTimezoneByIP } = require('../../../src/services/geolocation');
 
-      nock('https://ipapi.co').get('/json/').reply(500);
+      mockGeolocationError(null, 500);
 
       // First call uses fallback
       const result1 = await getTimezoneByIP('127.0.0.1');
@@ -473,7 +447,7 @@ describe('GeolocationService', () => {
       jest.resetModules();
       const { getTimezoneByIP } = require('../../../src/services/geolocation');
 
-      nock('https://ipapi.co').get('/json/').reply(500);
+      mockGeolocationError(null, 500);
 
       const result = await getTimezoneByIP('127.0.0.1');
 
@@ -494,11 +468,6 @@ describe('GeolocationService', () => {
   });
 
   describe('API key support', () => {
-    beforeEach(() => {
-      clearCache();
-      nock.cleanAll();
-    });
-
     test('should call unauthenticated URL when no API key is set', async () => {
       jest.resetModules();
       const {
@@ -507,7 +476,7 @@ describe('GeolocationService', () => {
       } = require('../../../src/services/geolocation');
       freshClear();
       // config.geolocationApiKey is null by default
-      const scope = nock('https://ipapi.co').get('/8.8.8.8/json/').reply(200, mockApiResponse);
+      const scope = mockGeolocationSuccess('8.8.8.8');
       await freshGet('8.8.8.8');
       expect(scope.isDone()).toBe(true);
     });
@@ -522,12 +491,10 @@ describe('GeolocationService', () => {
       freshClear();
       freshConfig.geolocationApiKey = 'test-key-abc';
       try {
-        const freeScope = nock('https://ipapi.co')
-          .get('/8.8.8.8/json/')
-          .reply(200, mockApiResponse);
-        const keyScope = nock('https://ipapi.co')
-          .get('/8.8.8.8/json/?key=test-key-abc')
-          .reply(200, mockApiResponse);
+        const freeScope = mockGeolocationSuccess('8.8.8.8');
+        const keyScope = mockGeolocationSuccess('8.8.8.8', MOCK_RESPONSES.SUCCESS, {
+          key: 'test-key-abc',
+        });
         await freshGet('8.8.8.8');
         expect(freeScope.isDone()).toBe(true);
         expect(keyScope.isDone()).toBe(false); // key not used when free tier succeeds
@@ -547,10 +514,10 @@ describe('GeolocationService', () => {
       freshClear();
       freshConfig.geolocationApiKey = 'test-key-abc';
       try {
-        nock('https://ipapi.co').get('/8.8.8.8/json/').reply(429, { error: 'Rate limited' });
-        const keyScope = nock('https://ipapi.co')
-          .get('/8.8.8.8/json/?key=test-key-abc')
-          .reply(200, mockApiResponse);
+        mockGeolocationRateLimit('8.8.8.8');
+        const keyScope = mockGeolocationSuccess('8.8.8.8', MOCK_RESPONSES.SUCCESS, {
+          key: 'test-key-abc',
+        });
         const result = await freshGet('8.8.8.8');
         expect(keyScope.isDone()).toBe(true);
         expect(result.city).toBe('Mountain View');
@@ -570,14 +537,8 @@ describe('GeolocationService', () => {
       freshConfig.geolocationApiKey = 'test-key-abc';
       try {
         // fetchWithRetry retries fetchFromAPI up to UPSTREAM_MAX_RETRIES (3) times = 4 total attempts
-        nock('https://ipapi.co')
-          .get('/8.8.8.8/json/')
-          .times(4)
-          .reply(429, { error: 'Rate limited' }, { 'Retry-After': '0' });
-        nock('https://ipapi.co')
-          .get('/8.8.8.8/json/?key=test-key-abc')
-          .times(4)
-          .reply(429, { error: 'Rate limited' }, { 'Retry-After': '0' });
+        mockGeolocationRateLimit('8.8.8.8', { times: 4, retryAfter: 0 });
+        mockGeolocationRateLimit('8.8.8.8', { times: 4, retryAfter: 0, key: 'test-key-abc' });
         await expect(freshGet('8.8.8.8')).rejects.toMatchObject({ rateLimited: true });
       } finally {
         freshConfig.geolocationApiKey = null;
@@ -596,9 +557,9 @@ describe('GeolocationService', () => {
       freshClear();
       freshConfig.geolocationApiKey = 'test-key-abc';
       try {
-        const keyScope = nock('https://ipapi.co')
-          .get('/8.8.8.8/json/?key=test-key-abc')
-          .reply(200, mockApiResponse);
+        const keyScope = mockGeolocationSuccess('8.8.8.8', MOCK_RESPONSES.SUCCESS, {
+          key: 'test-key-abc',
+        });
         await freshGet('8.8.8.8');
         expect(keyScope.isDone()).toBe(true); // key used on first request in production
       } finally {

--- a/tests/unit/services/health.test.js
+++ b/tests/unit/services/health.test.js
@@ -1,24 +1,23 @@
-const nock = require('nock');
 const {
   checkGeolocationAPI,
   checkCache,
   performHealthCheck,
 } = require('../../../src/services/health');
 const cache = require('../../../src/services/cache');
+const {
+  MOCK_RESPONSES,
+  mockGeolocationSuccess,
+  mockGeolocationError,
+  mockGeolocationNetworkError,
+} = require('../../helpers/nock-mocks');
+const { setupGeolocationTests } = require('../../helpers/test-setup');
 
 describe('Health Service', () => {
-  beforeEach(() => {
-    nock.cleanAll();
-    cache.flush();
-  });
-
-  afterAll(() => {
-    nock.restore();
-  });
+  setupGeolocationTests(() => cache.flush());
 
   describe('checkGeolocationAPI', () => {
     test('should return healthy when API is accessible', async () => {
-      nock('https://ipapi.co').get('/json/').reply(200, { ip: '8.8.8.8' });
+      mockGeolocationSuccess(null, MOCK_RESPONSES.MINIMAL);
 
       const result = await checkGeolocationAPI();
 
@@ -28,10 +27,7 @@ describe('Health Service', () => {
     });
 
     test('should return unhealthy when API times out', async () => {
-      nock('https://ipapi.co')
-        .get('/json/')
-        .delayConnection(3000) // Delay longer than timeout
-        .reply(200, {});
+      mockGeolocationSuccess(null, MOCK_RESPONSES.EMPTY, { delayConnection: 3000 });
 
       const result = await checkGeolocationAPI();
 
@@ -41,7 +37,7 @@ describe('Health Service', () => {
     });
 
     test('should return unhealthy when API returns 500', async () => {
-      nock('https://ipapi.co').get('/json/').reply(500, { error: 'Server Error' });
+      mockGeolocationError(null, 500, { error: 'Server Error' });
 
       const result = await checkGeolocationAPI();
 
@@ -50,7 +46,7 @@ describe('Health Service', () => {
     });
 
     test('should return unhealthy on network error', async () => {
-      nock('https://ipapi.co').get('/json/').replyWithError({ code: 'ECONNREFUSED' });
+      mockGeolocationNetworkError(null, 'ECONNREFUSED');
 
       const result = await checkGeolocationAPI();
 
@@ -59,7 +55,7 @@ describe('Health Service', () => {
     });
 
     test('should complete check within timeout period', async () => {
-      nock('https://ipapi.co').get('/json/').reply(200, {});
+      mockGeolocationSuccess(null, MOCK_RESPONSES.EMPTY);
 
       const startTime = Date.now();
       await checkGeolocationAPI();
@@ -111,7 +107,7 @@ describe('Health Service', () => {
 
   describe('performHealthCheck', () => {
     test('should return healthy when all checks pass', async () => {
-      nock('https://ipapi.co').get('/json/').reply(200, {});
+      mockGeolocationSuccess(null, MOCK_RESPONSES.EMPTY);
 
       const result = await performHealthCheck();
 
@@ -124,7 +120,7 @@ describe('Health Service', () => {
     });
 
     test('should return degraded when API check fails', async () => {
-      nock('https://ipapi.co').get('/json/').reply(500, {});
+      mockGeolocationError(null, 500);
 
       const result = await performHealthCheck();
 
@@ -134,7 +130,7 @@ describe('Health Service', () => {
     });
 
     test('should return degraded when cache check fails', async () => {
-      nock('https://ipapi.co').get('/json/').reply(200, {});
+      mockGeolocationSuccess(null, MOCK_RESPONSES.EMPTY);
 
       jest.spyOn(cache, 'getStats').mockImplementation(() => {
         throw new Error('Cache error');
@@ -150,7 +146,7 @@ describe('Health Service', () => {
     });
 
     test('should run checks in parallel', async () => {
-      nock('https://ipapi.co').get('/json/').delay(500).reply(200, {});
+      mockGeolocationSuccess(null, MOCK_RESPONSES.EMPTY, { delay: 500 });
 
       const startTime = Date.now();
       await performHealthCheck();
@@ -161,7 +157,7 @@ describe('Health Service', () => {
     });
 
     test('should include all required fields', async () => {
-      nock('https://ipapi.co').get('/json/').reply(200, {});
+      mockGeolocationSuccess(null, MOCK_RESPONSES.EMPTY);
 
       const result = await performHealthCheck();
 


### PR DESCRIPTION
## Summary

- Creates `tests/helpers/nock-mocks.js` with factory functions (`mockGeolocationSuccess`, `mockGeolocationError`, `mockGeolocationRateLimit`, `mockGeolocationNetworkError`, `mockGeolocationRegex`) that centralise all nock interceptor construction
- Creates `tests/helpers/test-setup.js` with `setupGeolocationTests`, `setupIntegrationTests`, and `setupSecurityTests` to replace repetitive `beforeEach`/`afterAll` boilerplate
- Updates 4 test files to use the helpers, eliminating 69 scattered inline nock setups and shared mock response objects

## Impact

Every nock interceptor in the test suite now goes through a typed, named function. Adding a new mock variant or changing the base URL requires one change in one file. Test files shrink and become more readable — the `what` of each test is no longer buried under HTTP plumbing.

## Test plan

- [x] All 305 tests pass (`npm test`)
- [x] Coverage remains ≥ 95% branches on geolocation service
- [x] No inline `nock('https://ipapi.co')` calls remain in any of the 4 updated test files
- [x] Pre-push CI (lint, format, unit, integration) passes

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)