### PR TITLE
ci: add presetConfig.types so refactor and chore(deps) appear in CHANGELOG (Closes #177)

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -24,7 +24,21 @@
     [
       "@semantic-release/release-notes-generator",
       {
-        "preset": "conventionalcommits"
+        "preset": "conventionalcommits",
+        "presetConfig": {
+          "types": [
+            { "type": "feat", "section": "Features", "hidden": false },
+            { "type": "fix", "section": "Bug Fixes", "hidden": false },
+            { "type": "perf", "section": "Performance Improvements", "hidden": false },
+            { "type": "refactor", "section": "Code Refactoring", "hidden": false },
+            { "type": "chore", "section": "Maintenance", "hidden": false },
+            { "type": "test", "section": "Tests", "hidden": true },
+            { "type": "docs", "section": "Documentation", "hidden": true },
+            { "type": "ci", "section": "CI", "hidden": true },
+            { "type": "build", "section": "Build", "hidden": true },
+            { "type": "style", "section": "Style", "hidden": true }
+          ]
+        }
       }
     ],
     "@semantic-release/changelog",


### PR DESCRIPTION
## What and Why

Releases triggered by `refactor:` or `chore(deps):` commits produced empty CHANGELOG bodies and GitHub release notes, even though semantic-release correctly cut the version.

**Root cause**: `commit-analyzer` and `release-notes-generator` were inconsistently configured. The analyzer's custom `releaseRules` marked `refactor` and `chore(deps)` as patch-releasing, but `release-notes-generator` used `preset: "conventionalcommits"` with no `presetConfig` — falling back to preset defaults that hide both types from output entirely.

**Fix**: Added `presetConfig.types` to the `release-notes-generator` plugin config, explicitly marking `refactor` and `chore` as visible. Types that never trigger releases (`test`, `docs`, `ci`, `build`, `style`) remain hidden.

Affected releases: v1.7.1, v1.6.4, v1.6.3 (empty bodies — not retroactively fixed). Future releases will have correct entries.

Closes #177