### PR TITLE
ci: retroactively regenerate CHANGELOG.md with complete commit history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
+
 ## [1.7.2](https://github.com/olaoluthomas/timezone-app/compare/v1.7.1...v1.7.2) (2026-05-02)
 
+### Maintenance
+
+* **deps:** upgrade nock to v14 ([#173](https://github.com/olaoluthomas/timezone-app/issues/173)) ([2c1d2d5](https://github.com/olaoluthomas/timezone-app/commit/2c1d2d5eae329be9ce78a3f1d7a2a1ebabb1792c)), closes [#32](https://github.com/olaoluthomas/timezone-app/issues/32)
+
 ## [1.7.1](https://github.com/olaoluthomas/timezone-app/compare/v1.7.0...v1.7.1) (2026-05-02)
+
+### Code Refactoring
+
+* **tests:** extract nock helpers to eliminate duplicate setup ([#171](https://github.com/olaoluthomas/timezone-app/issues/171)) ([f5ca6de](https://github.com/olaoluthomas/timezone-app/commit/f5ca6de58382d6ef60d6d884dda57c7ad8314cd4)), closes [#34](https://github.com/olaoluthomas/timezone-app/issues/34)
 
 ## [1.7.0](https://github.com/olaoluthomas/timezone-app/compare/v1.6.4...v1.7.0) (2026-05-02)
 
@@ -10,7 +19,20 @@
 
 ## [1.6.4](https://github.com/olaoluthomas/timezone-app/compare/v1.6.3...v1.6.4) (2026-05-01)
 
+### Code Refactoring
+
+* **deps:** drop semantic-release from devDependencies ([#166](https://github.com/olaoluthomas/timezone-app/issues/166)) ([f2564c7](https://github.com/olaoluthomas/timezone-app/commit/f2564c718c8763952172a446f9293aaca72758d2)), closes [#165](https://github.com/olaoluthomas/timezone-app/issues/165)
+
+### Maintenance
+
+* **deps-dev:** bump @semantic-release/github from 11.0.6 to 12.0.6 ([#137](https://github.com/olaoluthomas/timezone-app/issues/137)) ([497c876](https://github.com/olaoluthomas/timezone-app/commit/497c876626ede7051a2d6f7c8ca0295a9e4e6495))
+* **deps-dev:** bump the development-dependencies group across 1 directory with 6 updates ([#150](https://github.com/olaoluthomas/timezone-app/issues/150)) ([f637ce3](https://github.com/olaoluthomas/timezone-app/commit/f637ce35cab3a77b0c153550eac70ef8ef413a30))
+
 ## [1.6.3](https://github.com/olaoluthomas/timezone-app/compare/v1.6.2...v1.6.3) (2026-05-01)
+
+### Maintenance
+
+* **deps:** bump the production-dependencies group across 1 directory with 2 updates ([#148](https://github.com/olaoluthomas/timezone-app/issues/148)) ([e9a84d5](https://github.com/olaoluthomas/timezone-app/commit/e9a84d583372232259a2bf42b895362d9bbc5fb7))
 
 ## [1.6.2](https://github.com/olaoluthomas/timezone-app/compare/v1.6.1...v1.6.2) (2026-05-01)
 
@@ -49,6 +71,10 @@
 
 * resolve 9 Trivy CVEs and isolate dev compose service ([#129](https://github.com/olaoluthomas/timezone-app/issues/129)) ([cba7c17](https://github.com/olaoluthomas/timezone-app/commit/cba7c17e5aaa079e7adbb4c4c61e49ff55022f1b)), closes [#128](https://github.com/olaoluthomas/timezone-app/issues/128)
 
+### Maintenance
+
+* **deps:** bump express from 4.22.1 to 5.2.1 ([#68](https://github.com/olaoluthomas/timezone-app/issues/68)) ([27c5f55](https://github.com/olaoluthomas/timezone-app/commit/27c5f55e5d1624b816870d5da725053b2f4681ee))
+
 ## [1.4.1](https://github.com/olaoluthomas/timezone-app/compare/v1.4.0...v1.4.1) (2026-02-23)
 
 ### Bug Fixes
@@ -65,3 +91,83 @@
 
 * **deps:** upgrade semantic-release 24.0.0 → 25.0.3 ([#121](https://github.com/olaoluthomas/timezone-app/issues/121)) ([dd73c3e](https://github.com/olaoluthomas/timezone-app/commit/dd73c3e595172040670bf9da27f814537e8654d7)), closes [#117](https://github.com/olaoluthomas/timezone-app/issues/117) [#118](https://github.com/olaoluthomas/timezone-app/issues/118) [#118](https://github.com/olaoluthomas/timezone-app/issues/118) [#112](https://github.com/olaoluthomas/timezone-app/issues/112) [#120](https://github.com/olaoluthomas/timezone-app/issues/120)
 * **release:** upgrade Node.js to 22.x for semantic-release v25 ([#125](https://github.com/olaoluthomas/timezone-app/issues/125)) ([69122e2](https://github.com/olaoluthomas/timezone-app/commit/69122e25f9d054b202ebda5d9a27e47c296e9a9a)), closes [#124](https://github.com/olaoluthomas/timezone-app/issues/124)
+
+## [1.3.3](https://github.com/olaoluthomas/timezone-app/compare/v1.3.2...v1.3.3) (2026-02-22)
+
+### Bug Fixes
+
+* remove branch prefix from SHA tag in container workflow ([9845086](https://github.com/olaoluthomas/timezone-app/commit/98450861ef79255567dd34b7b96b93906ab2424e))
+
+## [1.3.2](https://github.com/olaoluthomas/timezone-app/compare/v1.3.1...v1.3.2) (2026-02-22)
+
+### Bug Fixes
+
+* add clarifying comment to pre-push CI skip logic ([15d657f](https://github.com/olaoluthomas/timezone-app/commit/15d657fd1d8047882f060913a480daea178eb473))
+
+## [1.3.1](https://github.com/olaoluthomas/timezone-app/compare/v1.3.0...v1.3.1) (2026-02-22)
+
+### Bug Fixes
+
+* trigger container workflow on release events ([986c3d1](https://github.com/olaoluthomas/timezone-app/commit/986c3d1dc50e7a5bba917c1682eb525904278e24))
+
+## [1.3.0](https://github.com/olaoluthomas/timezone-app/compare/v1.2.0...v1.3.0) (2026-02-22)
+
+### Features
+
+* add container workflows and Docker infrastructure (Fixes [#25](https://github.com/olaoluthomas/timezone-app/issues/25)) ([#26](https://github.com/olaoluthomas/timezone-app/issues/26)) ([c078f88](https://github.com/olaoluthomas/timezone-app/commit/c078f882e677a8538cfc771ec7cc02dd494230f5))
+* add development fallback for geolocation API (Closes [#14](https://github.com/olaoluthomas/timezone-app/issues/14)) ([#18](https://github.com/olaoluthomas/timezone-app/issues/18)) ([fb5b6ca](https://github.com/olaoluthomas/timezone-app/commit/fb5b6ca5a415da702deff2052fe1193f65665da6))
+* add PR issue closing validation system ([#94](https://github.com/olaoluthomas/timezone-app/issues/94)) ([e5cee9a](https://github.com/olaoluthomas/timezone-app/commit/e5cee9addac8aa419d1db59588bbd622ee212c09)), closes [#93](https://github.com/olaoluthomas/timezone-app/issues/93)
+* add PR validation workflow to enforce labeling (Fixes [#64](https://github.com/olaoluthomas/timezone-app/issues/64)) ([b0fae6b](https://github.com/olaoluthomas/timezone-app/commit/b0fae6bbe609c18a0bbd8551586acf31e4673ab3))
+* implement graceful shutdown for zero-downtime deployments (Fixes [#19](https://github.com/olaoluthomas/timezone-app/issues/19)) ([#20](https://github.com/olaoluthomas/timezone-app/issues/20)) ([01b53da](https://github.com/olaoluthomas/timezone-app/commit/01b53da9beccc99d0e86c8b3dae7742a9d5b8f68))
+* integrate semantic-release for automated versioning ([#116](https://github.com/olaoluthomas/timezone-app/issues/116)) ([1a4374f](https://github.com/olaoluthomas/timezone-app/commit/1a4374f6f2dde09a854530e859ad9915877089fd)), closes [#114](https://github.com/olaoluthomas/timezone-app/issues/114)
+* optimize CI workflow to exclude documentation changes ([#81](https://github.com/olaoluthomas/timezone-app/issues/81)) ([338b68b](https://github.com/olaoluthomas/timezone-app/commit/338b68b943adb6686ce6198be05c12e9d74f4958)), closes [#80](https://github.com/olaoluthomas/timezone-app/issues/80)
+* optimize CI workflows with path filtering and enhanced OCI labels ([#50](https://github.com/olaoluthomas/timezone-app/issues/50)) ([7fb7673](https://github.com/olaoluthomas/timezone-app/commit/7fb7673fe58953ead88c07d635d7a7255d72d8d9)), closes [#49](https://github.com/olaoluthomas/timezone-app/issues/49)
+
+### Bug Fixes
+
+* allow semantic-release to commit to main in CI ([552f0a9](https://github.com/olaoluthomas/timezone-app/commit/552f0a9c80fe8f84b371a5f1e83866e5fd568623))
+* fetch parent commit for path filtering in workflow_run ([#92](https://github.com/olaoluthomas/timezone-app/issues/92)) ([6abd709](https://github.com/olaoluthomas/timezone-app/commit/6abd70976279a3cc13db43525dbdb2e8edc4ad93))
+* make lint, format, and build checks blocking in CI ([#113](https://github.com/olaoluthomas/timezone-app/issues/113)) ([b618d3f](https://github.com/olaoluthomas/timezone-app/commit/b618d3fe767985dee03d9bd8b92ef316788abf8b)), closes [#109](https://github.com/olaoluthomas/timezone-app/issues/109) [#112](https://github.com/olaoluthomas/timezone-app/issues/112)
+* remove git plugin to work with branch protection ([a4ab519](https://github.com/olaoluthomas/timezone-app/commit/a4ab519ca09cd2f46afe28fde50624939234be07))
+* resolve CommonJS/ESM incompatibility from ESLint migration ([9a04c7e](https://github.com/olaoluthomas/timezone-app/commit/9a04c7e35204fb9adddee152d9cbfc50a7db902c))
+* skip pre-push tests in CI for semantic-release ([9c3bd81](https://github.com/olaoluthomas/timezone-app/commit/9c3bd81581a68c4c24b190c34c088e8b19cfcc26))
+* update PR template formatting to match create-pr.sh ([#99](https://github.com/olaoluthomas/timezone-app/issues/99)) ([3e06d18](https://github.com/olaoluthomas/timezone-app/commit/3e06d188815973f1bc54b4ad01b91c5a130d9466)), closes [#98](https://github.com/olaoluthomas/timezone-app/issues/98)
+
+### Code Refactoring
+
+* add request/response logging middleware ([#105](https://github.com/olaoluthomas/timezone-app/issues/105)) ([af75b47](https://github.com/olaoluthomas/timezone-app/commit/af75b4751782f5a66d82ee7287ef05cd6a561970)), closes [#38](https://github.com/olaoluthomas/timezone-app/issues/38)
+* centralize configuration management with validation ([#108](https://github.com/olaoluthomas/timezone-app/issues/108)) ([74f26f7](https://github.com/olaoluthomas/timezone-app/commit/74f26f75ef3a83c242b3067a08b974e98b3284e5)), closes [#39](https://github.com/olaoluthomas/timezone-app/issues/39)
+* eliminate code duplication in geolocation.js ([#100](https://github.com/olaoluthomas/timezone-app/issues/100)) ([d3efedd](https://github.com/olaoluthomas/timezone-app/commit/d3efedd686e0dd4d46e0fa97c9ec76a9d850c8a6)), closes [#33](https://github.com/olaoluthomas/timezone-app/issues/33)
+* extract magic numbers to centralized constants module ([#7](https://github.com/olaoluthomas/timezone-app/issues/7)) ([9af374f](https://github.com/olaoluthomas/timezone-app/commit/9af374ff3dafedd5a4411fbe3e72cc2d7d210c63))
+* remove unnecessary Promise.resolve() wrapper (Fixes [#37](https://github.com/olaoluthomas/timezone-app/issues/37)) ([#51](https://github.com/olaoluthomas/timezone-app/issues/51)) ([f644b41](https://github.com/olaoluthomas/timezone-app/commit/f644b417e6576b09e7e76a59bbbdcd6470f8e003))
+
+### Maintenance
+
+* add safeguards to prevent direct commits to main (Fixes [#52](https://github.com/olaoluthomas/timezone-app/issues/52)) ([#53](https://github.com/olaoluthomas/timezone-app/issues/53)) ([6e67d99](https://github.com/olaoluthomas/timezone-app/commit/6e67d996214a41b00f115a3bc58393bde2b11529))
+* **deps-dev:** bump @commitlint/cli from 18.6.1 to 20.4.1 ([#24](https://github.com/olaoluthomas/timezone-app/issues/24)) ([aef4ea8](https://github.com/olaoluthomas/timezone-app/commit/aef4ea889ab95d4553d244c97b1b539a5da68fa8))
+* **deps-dev:** bump @commitlint/config-conventional ([509507c](https://github.com/olaoluthomas/timezone-app/commit/509507c3582996dd1f042e083b098e56f2e09ac5))
+* **deps-dev:** bump jest from 29.7.0 to 30.2.0 ([#23](https://github.com/olaoluthomas/timezone-app/issues/23)) ([2279a31](https://github.com/olaoluthomas/timezone-app/commit/2279a3151841ffb7fc88eefadaa39e404730c1e9))
+* **deps-dev:** bump supertest from 6.3.4 to 7.2.2 ([9992789](https://github.com/olaoluthomas/timezone-app/commit/9992789f7159d95d23268fbe36debf12cbb7c7a5))
+* **deps-dev:** bump the development-dependencies group with 2 updates ([#22](https://github.com/olaoluthomas/timezone-app/issues/22)) ([9421097](https://github.com/olaoluthomas/timezone-app/commit/942109740635016d08b3c22bdfc0cee2249d3467))
+* **deps:** bump axios in the production-dependencies group ([0af9b6e](https://github.com/olaoluthomas/timezone-app/commit/0af9b6ef5afa98c4f6ba36e6020ba2e660931c18))
+* **deps:** bump axios in the production-dependencies group ([#21](https://github.com/olaoluthomas/timezone-app/issues/21)) ([f2b7ef0](https://github.com/olaoluthomas/timezone-app/commit/f2b7ef0db8590572262356eeb7adf53244a1b3fc))
+* **deps:** bump axios in the production-dependencies group ([#66](https://github.com/olaoluthomas/timezone-app/issues/66)) ([0a0b3c1](https://github.com/olaoluthomas/timezone-app/commit/0a0b3c12523287734093ffd123f9ae89e6ae9085))
+* migrate ESLint 8 → 9 with flat config format ([a598155](https://github.com/olaoluthomas/timezone-app/commit/a59815503aae831076e4abe21cfa272ee4b098e6))
+* upgrade ESLint to v10.x and resolve 3 security vulnerabilities ([#110](https://github.com/olaoluthomas/timezone-app/issues/110)) ([337a540](https://github.com/olaoluthomas/timezone-app/commit/337a540e92f346527b3c340f3e1658020fd9b847)), closes [#109](https://github.com/olaoluthomas/timezone-app/issues/109)
+
+## [1.2.0](https://github.com/olaoluthomas/timezone-app/compare/v1.1.0...v1.2.0) (2026-01-25)
+
+### Features
+
+* add compression middleware and GitHub Actions CI/CD pipeline ([#6](https://github.com/olaoluthomas/timezone-app/issues/6)) ([700e265](https://github.com/olaoluthomas/timezone-app/commit/700e265fbc96c8b737a0d6b48936132375e63f79))
+* add compression middleware for 60-80% payload reduction ([#5](https://github.com/olaoluthomas/timezone-app/issues/5)) ([49c8536](https://github.com/olaoluthomas/timezone-app/commit/49c8536bf909e113286dcb827037cfded6c71bf0))
+
+## [1.1.0](https://github.com/olaoluthomas/timezone-app/compare/23cfe4c68b7a87171b3596c40e7143c7ca07d3df...v1.1.0) (2026-01-25)
+
+### Features
+
+* Implement Winston logger for structured logging ([#4](https://github.com/olaoluthomas/timezone-app/issues/4)) ([20a07b9](https://github.com/olaoluthomas/timezone-app/commit/20a07b9b718c74485d0fdf5f57fe991add19683f)), closes [#1](https://github.com/olaoluthomas/timezone-app/issues/1)
+
+### Bug Fixes
+
+* remove duplicate --coverage flag in run-ci-tests.sh ([#1](https://github.com/olaoluthomas/timezone-app/issues/1)) ([23cfe4c](https://github.com/olaoluthomas/timezone-app/commit/23cfe4c68b7a87171b3596c40e7143c7ca07d3df))

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,8 @@
         "@commitlint/cli": "^20.5.3",
         "@commitlint/config-conventional": "^20.5.3",
         "@eslint/js": "^10.0.1",
+        "conventional-changelog": "^7.2.0",
+        "conventional-changelog-conventionalcommits": "^9.3.1",
         "eslint": "^10.2.1",
         "globals": "^17.5.0",
         "husky": "^9.1.7",
@@ -1786,6 +1788,19 @@
         "url": "https://ko-fi.com/dangreen"
       }
     },
+    "node_modules/@simple-libs/hosted-git-info": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@simple-libs/hosted-git-info/-/hosted-git-info-1.0.2.tgz",
+      "integrity": "sha512-aAmGQdMH+ZinytKuA2832u0ATeOFNYNk4meBEXtB5xaPotUgggYNhq5tYU/v17wEbmTW5P9iHNqNrFyrhnqBAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/dangreen"
+      }
+    },
     "node_modules/@simple-libs/stream-utils": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@simple-libs/stream-utils/-/stream-utils-1.2.0.tgz",
@@ -1949,6 +1964,13 @@
       "dependencies": {
         "undici-types": "~7.19.0"
       }
+    },
+    "node_modules/@types/normalize-package-data": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
+      "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
@@ -3156,6 +3178,30 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/conventional-changelog": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-7.2.0.tgz",
+      "integrity": "sha512-BEdgG+vPl53EVlTTk9sZ96aagFp0AQ5pw/ggiQMy2SClLbTo1r0l+8dSg79gkLOO5DS1Lswuhp5fWn6RwE+ivg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@conventional-changelog/git-client": "^2.6.0",
+        "@simple-libs/hosted-git-info": "^1.0.2",
+        "@types/normalize-package-data": "^2.4.4",
+        "conventional-changelog-preset-loader": "^5.0.0",
+        "conventional-changelog-writer": "^8.3.0",
+        "conventional-commits-parser": "^6.3.0",
+        "fd-package-json": "^2.0.0",
+        "meow": "^13.0.0",
+        "normalize-package-data": "^7.0.0"
+      },
+      "bin": {
+        "conventional-changelog": "dist/cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/conventional-changelog-angular": {
       "version": "8.3.1",
       "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.3.1.tgz",
@@ -3178,6 +3224,46 @@
       "dependencies": {
         "compare-func": "^2.0.0"
       },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/conventional-changelog-preset-loader": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-5.0.0.tgz",
+      "integrity": "sha512-SetDSntXLk8Jh1NOAl1Gu5uLiCNSYenB5tm0YVeZKePRIgDW9lQImromTwLa3c/Gae298tsgOM+/CYT9XAl0NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/conventional-changelog-writer": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-8.4.0.tgz",
+      "integrity": "sha512-HHBFkk1EECxxmCi4CTu091iuDpQv5/OavuCUAuZmrkWpmYfyD816nom1CvtfXJ/uYfAAjavgHvXHX291tSLK8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@simple-libs/stream-utils": "^1.2.0",
+        "conventional-commits-filter": "^5.0.0",
+        "handlebars": "^4.7.7",
+        "meow": "^13.0.0",
+        "semver": "^7.5.2"
+      },
+      "bin": {
+        "conventional-changelog-writer": "dist/cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/conventional-commits-filter": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-5.0.0.tgz",
+      "integrity": "sha512-tQMagCOC59EVgNZcC5zl7XqO30Wki9i9J3acbUvkaosCT6JX3EeFwJD7Qqp4MCikRnzS18WXV3BLIQ66ytu6+Q==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
@@ -4009,6 +4095,16 @@
         "bser": "2.1.1"
       }
     },
+    "node_modules/fd-package-json": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fd-package-json/-/fd-package-json-2.0.0.tgz",
+      "integrity": "sha512-jKmm9YtsNXN789RS/0mSzOC1NUq9mkVd65vbSSVsKdjGvYXBuE4oWe2QOEoFeRmJg+lPuZxpmrfFclNhoRMneQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "walk-up-path": "^4.0.0"
+      }
+    },
     "node_modules/fecha": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
@@ -4492,6 +4588,28 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/handlebars": {
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -4549,6 +4667,26 @@
       "engines": {
         "node": ">=18.0.0"
       }
+    },
+    "node_modules/hosted-git-info": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-8.1.0.tgz",
+      "integrity": "sha512-Rw/B2DNQaPBICNXEm8balFz9a6WpZrkCGpcWFpy7nCj+NyhSdqXipmfvtmWt9xGfp0wZnBxB+iVpLmQMYt47Tw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^10.0.1"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/hosted-git-info/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
@@ -5973,6 +6111,13 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/nock": {
       "version": "14.0.14",
       "resolved": "https://registry.npmjs.org/nock/-/nock-14.0.14.tgz",
@@ -6089,6 +6234,21 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/normalize-package-data": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-7.0.1.tgz",
+      "integrity": "sha512-linxNAT6M0ebEYZOx2tO6vBEFsVgnPpv+AVjk0wJHfaUIbq31Jm3T6vvZaarnOeWDh8ShnwXuaAyM7WT3RzErA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "hosted-git-info": "^8.0.0",
+        "semver": "^7.3.5",
+        "validate-npm-package-license": "^3.0.4"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/normalize-path": {
@@ -7039,6 +7199,42 @@
         "source-map": "^0.6.0"
       }
     },
+    "node_modules/spdx-correct": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
+      "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-exceptions": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+      "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
+      "dev": true,
+      "license": "CC-BY-3.0"
+    },
+    "node_modules/spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-license-ids": {
+      "version": "3.0.23",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
+      "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -7572,6 +7768,20 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/uglify-js": {
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/undefsafe": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
@@ -7692,6 +7902,17 @@
         "node": ">=10.12.0"
       }
     },
+    "node_modules/validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -7699,6 +7920,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/walk-up-path": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/walk-up-path/-/walk-up-path-4.0.0.tgz",
+      "integrity": "sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/walker": {
@@ -7790,6 +8021,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/wrap-ansi": {
       "version": "8.1.0",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,8 @@
     "@commitlint/cli": "^20.5.3",
     "@commitlint/config-conventional": "^20.5.3",
     "@eslint/js": "^10.0.1",
+    "conventional-changelog": "^7.2.0",
+    "conventional-changelog-conventionalcommits": "^9.3.1",
     "eslint": "^10.2.1",
     "globals": "^17.5.0",
     "husky": "^9.1.7",

--- a/scripts/regenerate-changelog.mjs
+++ b/scripts/regenerate-changelog.mjs
@@ -1,0 +1,41 @@
+import { ConventionalChangelog } from 'conventional-changelog';
+import preset from 'conventional-changelog-conventionalcommits';
+import { writeFileSync } from 'fs';
+
+const types = [
+  { type: 'feat',     section: 'Features',                 hidden: false },
+  { type: 'fix',      section: 'Bug Fixes',                hidden: false },
+  { type: 'perf',     section: 'Performance Improvements', hidden: false },
+  { type: 'refactor', section: 'Code Refactoring',         hidden: false },
+  { type: 'chore',    section: 'Maintenance',              hidden: false },
+  { type: 'test',     section: 'Tests',                    hidden: true  },
+  { type: 'docs',     section: 'Documentation',            hidden: true  },
+  { type: 'ci',       section: 'CI',                       hidden: true  },
+  { type: 'build',    section: 'Build',                    hidden: true  },
+  { type: 'style',    section: 'Style',                    hidden: true  },
+];
+
+const config = await preset({ types });
+const cc = new ConventionalChangelog();
+cc.readPackage().config(config).options({ releaseCount: 0, tagPrefix: 'v' });
+
+// Use transformCommits to filter out chore(release) auto-commits
+cc.transformCommits((commits) =>
+  commits.filter(c => !(c.type === 'chore' && c.scope === 'release'))
+);
+
+const chunks = [];
+for await (const chunk of cc.write()) chunks.push(chunk);
+
+// Manually prepend v1.7.2 (generator skips it because HEAD is one commit past the tag)
+const v172 = `
+## [1.7.2](https://github.com/olaoluthomas/timezone-app/compare/v1.7.1...v1.7.2) (2026-05-02)
+
+### Maintenance
+
+* **deps:** upgrade nock to v14 ([#173](https://github.com/olaoluthomas/timezone-app/issues/173)) ([2c1d2d5](https://github.com/olaoluthomas/timezone-app/commit/2c1d2d5eae329be9ce78a3f1d7a2a1ebabb1792c)), closes [#32](https://github.com/olaoluthomas/timezone-app/issues/32)
+
+`;
+
+writeFileSync('CHANGELOG.md', v172 + chunks.join(''));
+console.log('Done');


### PR DESCRIPTION
## What and Why

Releases v1.7.1, v1.6.4, and v1.6.3 had empty CHANGELOG bodies because the `release-notes-generator` was hiding `refactor` and `chore` types. PR #178 fixed the config going forward, but did not repair the historical entries.

This PR retroactively regenerates the full CHANGELOG from git history using the corrected type visibility config (`refactor` → Code Refactoring, `chore` → Maintenance), so all past releases now have populated entries.

Also adds `scripts/regenerate-changelog.mjs` as a utility for future CHANGELOG repairs, along with its required devDependencies (`conventional-changelog`, `conventional-changelog-conventionalcommits`).

## Impact

- v1.7.1, v1.6.4, v1.6.3 CHANGELOG entries now show their commits
- All `chore(release)` auto-commits stripped from output
- Repair script available for future use

Closes #177