### PR TITLE
docs: add commit split rule for src/ and tests/ changes (Closes #181)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,7 +123,21 @@ git commit -m "test: add integration tests for health endpoint"
 - `ci`: CI/CD pipeline changes
 - `build`: Build system changes
 
-> **Rule**: if every changed file is under `tests/`, the type **must** be `test:` — even when the work is structural (e.g. extracting test helpers). `test:` does not trigger a release. `refactor:` does.
+> **Rule 1 — type by directory**: if every changed file is under `tests/`, the type **must** be `test:` — even when the work is structural (e.g. extracting test helpers). `test:` does not trigger a release. `refactor:` does.
+
+> **Rule 2 — split `src/` and `tests/` into separate commits**: when a change touches both `src/` and `tests/`, stage and commit them in two separate commits. The `src/` commit uses the appropriate type; the `tests/` commit uses `test:`. This keeps the CHANGELOG accurate — a `refactor:` commit correctly triggers a patch release and appears in the release notes, while the accompanying `test:` commit does not.
+>
+> ```bash
+> # ✅ Correct
+> git add src/
+> git commit -m "refactor(controllers): extract route handlers to controller layer"
+> git add tests/
+> git commit -m "test(controllers): add unit tests for healthController and timezoneController"
+>
+> # ❌ Wrong — CHANGELOG entry will show "refactor" but the diff includes test files
+> git add src/ tests/
+> git commit -m "refactor(controllers): extract route handlers and add tests"
+> ```
 
 ### 5. Automated Git Workflow
 

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -53,7 +53,21 @@ ci: add security audit step to workflow
 build: switch from ts-node to tsx
 ```
 
-> **Rule**: if every changed file is under `tests/`, the type **must** be `test:` — even when the work is structural (e.g. extracting test helpers). `test:` does not trigger a release. `refactor:` does (patch).
+> **Rule 1 — type by directory**: if every changed file is under `tests/`, the type **must** be `test:` — even when the work is structural (e.g. extracting test helpers). `test:` does not trigger a release. `refactor:` does (patch).
+
+> **Rule 2 — split `src/` and `tests/` into separate commits**: when a change touches both `src/` and `tests/`, stage and commit them independently. The `src/` commit uses the appropriate type (`feat:`, `fix:`, `refactor:`, etc.); the `tests/` commit uses `test:`. This keeps the CHANGELOG accurate and ensures `test:` commits (which don't trigger releases) are never bundled with types that do.
+>
+> ```bash
+> # ✅ Correct — two commits
+> git add src/controllers/
+> git commit -m "refactor(controllers): extract route handlers to controller layer"
+> git add tests/unit/controllers/
+> git commit -m "test(controllers): add unit tests for healthController and timezoneController"
+>
+> # ❌ Wrong — one commit mixing src/ and tests/
+> git add src/controllers/ tests/unit/controllers/
+> git commit -m "refactor(controllers): extract route handlers and add tests"
+> ```
 
 ## ⛔ What NOT to Do
 
@@ -72,6 +86,19 @@ git commit -m "some changes"
 
 # Good PR title
 "docs: update README with API examples (Fixes #88)"
+```
+
+**❌ DO NOT mix `src/` and `tests/` in a single commit:**
+```bash
+# Bad — one commit bundles implementation and tests
+git add src/controllers/ tests/unit/controllers/
+git commit -m "refactor(controllers): extract route handlers and add tests"
+
+# Good — two commits, each with the right type
+git add src/controllers/
+git commit -m "refactor(controllers): extract route handlers to controller layer"
+git add tests/unit/controllers/
+git commit -m "test(controllers): add unit tests for healthController and timezoneController"
 ```
 
 **❌ DO NOT skip creating issues:**
@@ -152,11 +179,14 @@ git checkout -b refactor/issue-37-remove-promise-resolve
 # 3. Refactor and verify tests still pass
 npm test
 
-# 4. Commit and push
-git commit -m "refactor: remove unnecessary Promise.resolve() wrapper"
-git push -u origin refactor/issue-37-remove-promise-resolve
+# 4. Commit src/ and tests/ separately
+git add src/
+git commit -m "refactor: remove unnecessary Promise.resolve() wrapper (Closes #37)"
+git add tests/
+git commit -m "test: update geolocation tests for Promise.resolve removal"
 
-# 5. Create PR
+# 5. Push and create PR
+git push -u origin refactor/issue-37-remove-promise-resolve
 # Preferred: GitHub MCP create_pull_request | Fallback: npm run create-pr
 ```
 


### PR DESCRIPTION
## Summary

Enforces a mandatory rule that `src/` and `tests/` changes must be in separate commits. This prevents `test:` commits (which don't trigger releases) from being bundled with types that do, keeping the CHANGELOG accurate.

## Impact

- CONTRIBUTING.md: renamed existing rule to "Rule 1", added "Rule 2 — split src/ and tests/ into separate commits" with before/after code examples
- WORKFLOW.md: added "Rule 2" under Commit Message Format, added a `❌ DO NOT mix src/ and tests/` block in "What NOT to Do", updated the Refactoring Code example to show two separate commits

## Test plan

- [ ] Verify CONTRIBUTING.md Rule 2 section renders correctly on GitHub
- [ ] Verify WORKFLOW.md "What NOT to Do" section shows the new block

Closes #181

🤖 Generated with [Claude Code](https://claude.ai/claude-code)