### PR TITLE
feat(ui): create globe component using Globe.GL (Closes #72)

### DIFF
--- a/src/public/index.html
+++ b/src/public/index.html
@@ -141,6 +141,19 @@
             flex: 1;
         }
 
+        /* Globe section */
+        .globe-section {
+            margin-top: 30px;
+            border-radius: 15px;
+            overflow: hidden;
+            background: #0a0a2e;
+        }
+
+        #globe-container {
+            width: 100%;
+            height: 420px;
+        }
+
         @media (max-width: 600px) {
             .container {
                 padding: 20px;
@@ -158,6 +171,10 @@
             .time-display .info-value {
                 font-size: 1.5em;
             }
+
+            #globe-container {
+                height: 300px;
+            }
         }
     </style>
 </head>
@@ -170,9 +187,15 @@
         <div id="content">
             <div class="loading">Loading your location...</div>
         </div>
+        <div id="globe-section" class="globe-section" hidden>
+            <div id="globe-container"></div>
+        </div>
     </div>
 
+    <script src="https://cdn.jsdelivr.net/npm/globe.gl@2/dist/globe.gl.min.js"></script>
     <script>
+        let globeInstance = null;
+
         async function fetchTimezoneInfo() {
             let errorMessage = null;
             let errorClass = 'error error--critical';
@@ -255,6 +278,27 @@
             `;
 
             updateCurrentTime(data.timezone);
+            initGlobe();
+        }
+
+        function initGlobe() {
+            const section = document.getElementById('globe-section');
+            section.removeAttribute('hidden');
+
+            requestAnimationFrame(() => {
+                const container = document.getElementById('globe-container');
+                globeInstance = Globe()
+                    .globeImageUrl('//unpkg.com/three-globe/example/img/earth-day.jpg')
+                    .backgroundImageUrl('//unpkg.com/three-globe/example/img/night-sky.png')
+                    .width(container.clientWidth)
+                    .height(container.clientHeight)(container);
+
+                window.addEventListener('resize', () => {
+                    if (globeInstance) {
+                        globeInstance.width(container.clientWidth);
+                    }
+                });
+            });
         }
 
         function updateCurrentTime(timezone) {


### PR DESCRIPTION
## Summary

Adds a Globe.GL-powered 3D globe to the UI as a new section below the location info card. The globe renders after the timezone API response is received, showing an Earth texture with a night-sky background. This is the foundational component for issues #71 (location pin), #73 (3D tuning), #74 (map/terrain modes), and #75 (tooltip).

## Implementation notes

- Globe.GL loaded via jsDelivr CDN (`globe.gl@2/dist/globe.gl.min.js`) — no npm install, no build step
- Earth day texture and night-sky background loaded from `unpkg.com/three-globe` — single static images, no tile-server rate limit exposure
- Globe section uses the `hidden` attribute and is revealed (via `removeAttribute('hidden')`) only after the API data loads — no empty dark box during the loading state
- `requestAnimationFrame` ensures `clientWidth`/`clientHeight` are computed after layout, giving Globe.GL accurate initial dimensions
- Resize listener updates globe width on window resize
- Responsive: 420px height on desktop, 300px on mobile (≤ 600px)

## Test plan

- [ ] Start dev server (`npm run dev`), visit `http://localhost:3000`
- [ ] Confirm globe renders below the info card after location data loads
- [ ] Confirm globe does NOT appear during the "Loading your location..." state
- [ ] Confirm Earth texture and night-sky background are visible
- [ ] Resize browser window — globe width adjusts
- [ ] On mobile viewport (≤ 600px) — globe height is 300px
- [ ] `npm test` — all existing tests pass (no backend changes)

Closes #72

🤖 Generated with [Claude Code](https://claude.ai/claude-code)