### PR TITLE
feat(ui): improve globe texture resolution and enforce max zoom (Closes #73)

### DIFF
--- a/src/public/index.html
+++ b/src/public/index.html
@@ -327,7 +327,7 @@
             // Re-use existing instance — pan to the new location
             if (globeInstance) {
                 if (lat !== null) {
-                    globeInstance.pointOfView({ lat, lng, altitude: 0.5 }, 1500);
+                    globeInstance.pointOfView({ lat, lng, altitude: 0.35 }, 1500);
                 }
                 return;
             }
@@ -348,7 +348,7 @@
                 const container = document.getElementById('globe-container');
 
                 globeInstance = Globe()
-                    .globeImageUrl('//unpkg.com/three-globe/example/img/earth-day.jpg')
+                    .globeImageUrl('//unpkg.com/three-globe/example/img/earth-blue-marble.jpg')
                     .backgroundImageUrl('//unpkg.com/three-globe/example/img/night-sky.png')
                     .onGlobeReady(() => {
                         container.classList.add('ready');
@@ -357,11 +357,16 @@
                         // Keep the globe stationary on the user's location
                         globeInstance.controls().autoRotate = false;
 
+                        // Prevent zooming closer than altitude 0.15 — texture degrades below this
+                        const MIN_ALTITUDE = 0.15;
+                        globeInstance.controls().minDistance =
+                            globeInstance.getGlobeRadius() * (1 + MIN_ALTITUDE);
+
                         if (lat !== null && lng !== null) {
                             // Snap to hemisphere, then animate zoom-in over 2 s
                             globeInstance.pointOfView({ lat, lng, altitude: 2.5 }, 0);
                             setTimeout(() => {
-                                globeInstance.pointOfView({ lat, lng, altitude: 0.5 }, 2000);
+                                globeInstance.pointOfView({ lat, lng, altitude: 0.35 }, 2000);
                             }, 300);
 
                             addLocationMarker(data);


### PR DESCRIPTION
## Summary

- Swaps the globe texture from `earth-day.jpg` to `earth-blue-marble.jpg` (NASA Blue Marble composite via the same `unpkg.com/three-globe` CDN path) — significantly sharper coastlines and terrain detail at close zoom
- Enforces a minimum zoom altitude of 0.15 via `controls().minDistance`, preventing users from zooming past the point where any static texture looks acceptable
- Tightens the on-load auto-zoom target from altitude 0.5 → 0.35, taking advantage of the better texture to land at a more informative regional view

Closes #73

## Test plan

- [ ] Globe loads with richer color/detail visible even at default zoom
- [ ] Zooming in manually stops at ~country level (altitude ~0.15); texture stays sharp
- [ ] On load: zoom animation settles closer than before (0.35 vs 0.5)
- [ ] Drag/rotate still works; `autoRotate` stays off
- [ ] Resize: globe dimensions update correctly
- [ ] `npm test` — all 334 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)