### PR TITLE
fix(ui): remove dividing border between globe and info strip (Closes #190)

### DIFF
--- a/src/public/index.html
+++ b/src/public/index.html
@@ -14,7 +14,7 @@
 
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
-            background: #0a0a2e;
+            background: white;
             height: 100vh;
             height: 100dvh;
             overflow: hidden;
@@ -57,6 +57,7 @@
             min-height: 0;
             position: relative;
             background: #0a0a2e;
+            margin: 0 24px;
         }
 
         #globe-container {
@@ -199,6 +200,7 @@
                 flex: none;
                 height: 60vw;
                 min-height: 240px;
+                margin: 0 12px;
             }
 
             h1 { font-size: 1em; }

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -14,7 +14,7 @@
 
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
-            background: white;
+            background: #0a0a2e;
             height: 100vh;
             height: 100dvh;
             overflow: hidden;
@@ -57,7 +57,6 @@
             min-height: 0;
             position: relative;
             background: #0a0a2e;
-            margin: 0 24px;
         }
 
         #globe-container {
@@ -155,7 +154,6 @@
             flex-wrap: wrap;
             gap: 14px;
             align-items: stretch;
-            border-top: 3px solid #667eea;
             flex-shrink: 0;
         }
 
@@ -200,7 +198,6 @@
                 flex: none;
                 height: 60vw;
                 min-height: 240px;
-                margin: 0 12px;
             }
 
             h1 { font-size: 1em; }


### PR DESCRIPTION
## Summary

Removes the `border-top: 3px solid #667eea` line that separated the globe view from the info strip below it, allowing the two sections to sit flush against each other without a visual divider.

Closes #190

## Test plan

- [ ] No purple border line visible between the globe and the info strip
- [ ] Globe and info strip sit flush against each other
- [ ] All other layout unchanged
- [ ] `npm test` — all 345 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)