### PR TITLE
docs(workflow): require merge commit strategy for dev→main PRs (Closes #193)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -456,23 +456,28 @@ Before merging any PR, verify:
 
 #### Merge Methods
 
-This project uses **squash merging** for all PRs to maintain a clean git history.
+The merge method depends on the PR direction:
 
-**Squash Merge (Default):**
+| PR direction | Method | Why |
+|---|---|---|
+| feature / fix / docs → `dev` | **Squash and merge** | Collapses WIP commits into one clean logical commit on dev |
+| `dev` → `main` | **Create a merge commit** | Preserves all individual commits so semantic-release generates correct CHANGELOG entries |
+
+> ⚠️ **Never squash-merge `dev` into `main`.** Squashing collapses all commits into one, so semantic-release sees only a single entry and generates a one-line CHANGELOG instead of individual entries per feature/fix.
+
+**Feature/fix → dev (Squash and merge):**
 ```
 # Preferred: GitHub MCP merge_pull_request (merge_method: squash)
 # Fallback:  gh pr merge <PR-NUMBER> --squash --delete-branch
 ```
 
-**Benefits:**
-- Clean, linear git history
-- Single commit per feature/fix
-- Easier to revert if needed
-- Removes clutter from multiple work-in-progress commits
+**dev → main (Create a merge commit):**
+```
+# Preferred: GitHub MCP merge_pull_request (merge_method: merge)
+# Fallback:  gh pr merge <PR-NUMBER> --merge --delete-branch
+```
 
-**When to use other methods:**
-- **Standard Merge:** Never (creates merge commits, clutters history)
-- **Rebase Merge:** Never (loses PR context, complicates tracking)
+**Rebase Merge:** Never — rewrites commit SHAs, causing hash mismatches between dev and main.
 
 #### Single PR Merge
 

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -237,6 +237,17 @@ All PRs **MUST**:
 - ✅ Maintain or improve code coverage (96%+)
 - ✅ Have appropriate labels applied (automatic via script)
 
+### Merge Method by PR Direction
+
+> ⚠️ **The merge method is critical for correct CHANGELOG generation.**
+
+| PR direction | Required method | Forbidden |
+|---|---|---|
+| feature / fix / docs → `dev` | **Squash and merge** | — |
+| `dev` → `main` | **Create a merge commit** | ❌ Squash, ❌ Rebase |
+
+Squash-merging `dev` into `main` collapses all commits into one — semantic-release sees a single commit and produces one CHANGELOG line instead of individual entries per feature/fix.
+
 ## Common Mistakes
 
 ### ❌ Mistake: Committing to main


### PR DESCRIPTION
## Summary

Fixes the incorrect "squash merging for all PRs" rule in `CONTRIBUTING.md` and adds an explicit merge-method table to `WORKFLOW.md`. The root cause of the collapsed v1.8.0 CHANGELOG was squash-merging dev→main — this documents the correct approach to prevent recurrence.

**Rule:**
- feature/fix/docs → `dev`: **Squash and merge** (keeps dev history clean)
- `dev` → `main`: **Create a merge commit** (preserves individual commits for semantic-release)

Closes #193

## Test plan

- [ ] `CONTRIBUTING.md` Merge Methods section shows the direction-specific table and warning
- [ ] `WORKFLOW.md` PR Requirements section includes the merge method table
- [ ] Future dev→main PRs use merge commit and produce correct multi-entry CHANGELOGs

🤖 Generated with [Claude Code](https://claude.com/claude-code)