### PR TITLE
feat: add live weather integration with globe overlay (Closes #127, #200)

### DIFF
--- a/src/controllers/timezoneController.js
+++ b/src/controllers/timezoneController.js
@@ -1,4 +1,5 @@
 const geolocationService = require('../services/geolocation');
+const { getWeather } = require('../services/weather');
 const { APIError } = require('../middleware/error-handler');
 
 async function getTimezone(req, res, next) {
@@ -17,7 +18,10 @@ async function getTimezone(req, res, next) {
     const clientIP = req.ip;
     const timezoneInfo = await geolocationService.getTimezoneByIP(clientIP);
     if (!res.headersSent) {
-      res.json(timezoneInfo);
+      const weather = await getWeather(timezoneInfo.latitude, timezoneInfo.longitude).catch(
+        () => null
+      );
+      res.json({ ...timezoneInfo, weather });
     }
   } catch (error) {
     if (res.headersSent) return;

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -252,6 +252,10 @@
             <span class="chip-label">IP Address</span>
             <span class="chip-value" id="info-ip">--</span>
         </div>
+        <div class="info-chip" id="weather-chip" hidden>
+            <span class="chip-label">Weather</span>
+            <span class="chip-value" id="info-weather">--</span>
+        </div>
     </div>
 
     <!--
@@ -305,6 +309,12 @@
             document.getElementById('info-coords').textContent   =
                 `${Math.abs(data.latitude).toFixed(4)}°${latDir}, ${Math.abs(data.longitude).toFixed(4)}°${lngDir}`;
             document.getElementById('info-ip').textContent       = data.ip;
+
+            if (data.weather) {
+                document.getElementById('info-weather').textContent =
+                    `${data.weather.temperature}${data.weather.temperatureUnit} · ${data.weather.condition}`;
+                document.getElementById('weather-chip').removeAttribute('hidden');
+            }
 
             document.getElementById('info-strip').removeAttribute('hidden');
             updateCurrentTime(data.timezone);

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -146,6 +146,49 @@
             border-top: 3px solid #f59e0b;
         }
 
+        /* ── Weather overlay (top-left of globe) ── */
+        .weather-overlay {
+            position: absolute;
+            top: 12px;
+            left: 12px;
+            z-index: 5;
+            background: rgba(10, 10, 46, 0.75);
+            backdrop-filter: blur(8px);
+            border-radius: 10px;
+            padding: 10px 14px;
+            color: white;
+            border: 1px solid rgba(255, 255, 255, 0.12);
+            pointer-events: none;
+        }
+
+        .weather-top {
+            display: flex;
+            align-items: center;
+            gap: 6px;
+            margin-bottom: 3px;
+        }
+
+        .weather-icon { font-size: 1.8em; line-height: 1; }
+
+        .weather-temp {
+            font-size: 1.3em;
+            font-weight: 700;
+            line-height: 1;
+        }
+
+        .weather-condition {
+            font-size: 0.7em;
+            color: rgba(255, 255, 255, 0.72);
+            margin-bottom: 5px;
+        }
+
+        .weather-details {
+            font-size: 0.68em;
+            color: rgba(255, 255, 255, 0.55);
+            display: flex;
+            gap: 8px;
+        }
+
         /* ── Info strip ── */
         .info-strip {
             background: white;
@@ -228,6 +271,7 @@
     <div class="globe-hero">
         <div id="globe-container"></div>
         <div class="globe-loading" id="globe-loading">Detecting your location…</div>
+        <div id="weather-overlay" class="weather-overlay" hidden></div>
         <div id="error-banner" class="error-banner" hidden></div>
     </div>
 
@@ -251,10 +295,6 @@
         <div class="info-chip">
             <span class="chip-label">IP Address</span>
             <span class="chip-value" id="info-ip">--</span>
-        </div>
-        <div class="info-chip" id="weather-chip" hidden>
-            <span class="chip-label">Weather</span>
-            <span class="chip-value" id="info-weather">--</span>
         </div>
     </div>
 
@@ -311,9 +351,18 @@
             document.getElementById('info-ip').textContent       = data.ip;
 
             if (data.weather) {
-                document.getElementById('info-weather').textContent =
-                    `${data.weather.temperature}${data.weather.temperatureUnit} · ${data.weather.condition}`;
-                document.getElementById('weather-chip').removeAttribute('hidden');
+                const overlay = document.getElementById('weather-overlay');
+                overlay.innerHTML =
+                    '<div class="weather-top">' +
+                        `<span class="weather-icon">${data.weather.icon}</span>` +
+                        `<span class="weather-temp">${data.weather.temperature}${data.weather.temperatureUnit}</span>` +
+                    '</div>' +
+                    `<div class="weather-condition">${data.weather.condition}</div>` +
+                    '<div class="weather-details">' +
+                        `<span>💨 ${data.weather.windSpeed} ${data.weather.windUnit}</span>` +
+                        `<span>💧 ${data.weather.humidity}%</span>` +
+                    '</div>';
+                overlay.removeAttribute('hidden');
             }
 
             document.getElementById('info-strip').removeAttribute('hidden');

--- a/src/services/weather.js
+++ b/src/services/weather.js
@@ -1,0 +1,79 @@
+const axios = require('axios');
+const NodeCache = require('node-cache');
+
+const WEATHER_TTL = 1800; // 30 minutes
+const weatherCache = new NodeCache({ stdTTL: WEATHER_TTL, useClones: false, checkperiod: 0 });
+
+const OPEN_METEO_BASE = 'https://api.open-meteo.com/v1/forecast';
+
+const WMO_CODES = {
+  0: 'Clear sky',
+  1: 'Mainly clear',
+  2: 'Partly cloudy',
+  3: 'Overcast',
+  45: 'Fog',
+  48: 'Icy fog',
+  51: 'Light drizzle',
+  53: 'Drizzle',
+  55: 'Heavy drizzle',
+  56: 'Light freezing drizzle',
+  57: 'Heavy freezing drizzle',
+  61: 'Light rain',
+  63: 'Rain',
+  65: 'Heavy rain',
+  66: 'Light freezing rain',
+  67: 'Heavy freezing rain',
+  71: 'Light snow',
+  73: 'Snow',
+  75: 'Heavy snow',
+  77: 'Snow grains',
+  80: 'Light showers',
+  81: 'Showers',
+  82: 'Heavy showers',
+  85: 'Light snow showers',
+  86: 'Heavy snow showers',
+  95: 'Thunderstorm',
+  96: 'Thunderstorm with hail',
+  99: 'Thunderstorm with heavy hail',
+};
+
+async function getWeather(latitude, longitude) {
+  const cacheKey = `weather:${latitude},${longitude}`;
+  const cached = weatherCache.get(cacheKey);
+  if (cached !== undefined) {
+    return { ...cached, cached: true };
+  }
+
+  try {
+    const response = await axios.get(OPEN_METEO_BASE, {
+      params: {
+        latitude,
+        longitude,
+        current: 'temperature_2m,weather_code,wind_speed_10m,relative_humidity_2m',
+        wind_speed_unit: 'mph',
+      },
+      timeout: 5000,
+    });
+
+    const { current, current_units } = response.data;
+    const weather = {
+      temperature: current.temperature_2m,
+      temperatureUnit: current_units.temperature_2m,
+      condition: WMO_CODES[current.weather_code] ?? 'Unknown',
+      windSpeed: current.wind_speed_10m,
+      windUnit: current_units.wind_speed_10m,
+      humidity: current.relative_humidity_2m,
+    };
+
+    weatherCache.set(cacheKey, weather);
+    return { ...weather, cached: false };
+  } catch {
+    return null;
+  }
+}
+
+function clearWeatherCache() {
+  weatherCache.flushAll();
+}
+
+module.exports = { getWeather, clearWeatherCache };

--- a/src/services/weather.js
+++ b/src/services/weather.js
@@ -37,6 +37,37 @@ const WMO_CODES = {
   99: 'Thunderstorm with heavy hail',
 };
 
+const WMO_ICONS = {
+  0: '☀️',
+  1: '🌤️',
+  2: '⛅',
+  3: '☁️',
+  45: '🌫️',
+  48: '🌫️',
+  51: '🌦️',
+  53: '🌦️',
+  55: '🌧️',
+  56: '🌨️',
+  57: '🌨️',
+  61: '🌧️',
+  63: '🌧️',
+  65: '🌧️',
+  66: '🌨️',
+  67: '🌨️',
+  71: '🌨️',
+  73: '❄️',
+  75: '❄️',
+  77: '❄️',
+  80: '🌦️',
+  81: '🌧️',
+  82: '🌩️',
+  85: '🌨️',
+  86: '❄️',
+  95: '⛈️',
+  96: '⛈️',
+  99: '⛈️',
+};
+
 async function getWeather(latitude, longitude) {
   const cacheKey = `weather:${latitude},${longitude}`;
   const cached = weatherCache.get(cacheKey);
@@ -60,6 +91,7 @@ async function getWeather(latitude, longitude) {
       temperature: current.temperature_2m,
       temperatureUnit: current_units.temperature_2m,
       condition: WMO_CODES[current.weather_code] ?? 'Unknown',
+      icon: WMO_ICONS[current.weather_code] ?? '🌡️',
       windSpeed: current.wind_speed_10m,
       windUnit: current_units.wind_speed_10m,
       humidity: current.relative_humidity_2m,

--- a/tests/helpers/nock-mocks.js
+++ b/tests/helpers/nock-mocks.js
@@ -1,6 +1,7 @@
 const nock = require('nock');
 
 const IPAPI_BASE = 'https://ipapi.co';
+const OPEN_METEO_BASE = 'https://api.open-meteo.com';
 
 const MOCK_RESPONSES = {
   SUCCESS: {
@@ -85,12 +86,49 @@ function cleanMocks() {
   nock.cleanAll();
 }
 
+const MOCK_WEATHER_RESPONSE = {
+  latitude: 37.4056,
+  longitude: -122.0775,
+  current_units: {
+    temperature_2m: '°C',
+    weather_code: 'wmo code',
+    wind_speed_10m: 'mp/h',
+    relative_humidity_2m: '%',
+  },
+  current: {
+    temperature_2m: 18.5,
+    weather_code: 1,
+    wind_speed_10m: 5.2,
+    relative_humidity_2m: 65,
+  },
+};
+
+function mockWeatherSuccess(lat, lng, overrides = {}) {
+  const response = {
+    ...MOCK_WEATHER_RESPONSE,
+    latitude: lat,
+    longitude: lng,
+    current: { ...MOCK_WEATHER_RESPONSE.current, ...overrides },
+  };
+  return nock(OPEN_METEO_BASE).get('/v1/forecast').query(true).reply(200, response);
+}
+
+function mockWeatherError(lat, lng, statusCode = 500) {
+  return nock(OPEN_METEO_BASE)
+    .get('/v1/forecast')
+    .query(true)
+    .reply(statusCode, { error: 'upstream error' });
+}
+
 module.exports = {
   MOCK_RESPONSES,
+  MOCK_WEATHER_RESPONSE,
   mockGeolocationSuccess,
   mockGeolocationError,
   mockGeolocationRateLimit,
   mockGeolocationNetworkError,
   mockGeolocationRegex,
+  mockWeatherSuccess,
+  mockWeatherError,
   cleanMocks,
 };

--- a/tests/unit/controllers/timezoneController.test.js
+++ b/tests/unit/controllers/timezoneController.test.js
@@ -1,8 +1,10 @@
 const { getTimezone } = require('../../../src/controllers/timezoneController');
 const { APIError } = require('../../../src/middleware/error-handler');
 const geolocationService = require('../../../src/services/geolocation');
+const weatherService = require('../../../src/services/weather');
 
 jest.mock('../../../src/services/geolocation');
+jest.mock('../../../src/services/weather');
 // error-handler uses config and logger; mock both to keep unit test isolated
 jest.mock('../../../src/config', () => ({ isDevelopment: false }));
 jest.mock('../../../src/utils/logger', () => ({ error: jest.fn(), warn: jest.fn() }));
@@ -12,6 +14,8 @@ const MOCK_TIMEZONE_RESULT = {
   city: 'Mountain View',
   timezone: 'America/Los_Angeles',
   currentTime: '2026-01-01T12:00:00-08:00',
+  latitude: 37.4056,
+  longitude: -122.0775,
   cached: false,
 };
 
@@ -20,6 +24,7 @@ describe('Timezone Controller', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    weatherService.getWeather.mockResolvedValue(null);
     req = { ip: '8.8.8.8' };
     res = {
       status: jest.fn().mockReturnThis(),
@@ -43,7 +48,7 @@ describe('Timezone Controller', () => {
     test('responds with the timezone result', async () => {
       geolocationService.getTimezoneByIP.mockResolvedValue(MOCK_TIMEZONE_RESULT);
       await getTimezone(req, res, next);
-      expect(res.json).toHaveBeenCalledWith(MOCK_TIMEZONE_RESULT);
+      expect(res.json).toHaveBeenCalledWith(expect.objectContaining(MOCK_TIMEZONE_RESULT));
     });
 
     test('registers timeout listener on res', async () => {

--- a/tests/unit/services/weather.test.js
+++ b/tests/unit/services/weather.test.js
@@ -1,0 +1,85 @@
+const nock = require('nock');
+const { getWeather, clearWeatherCache } = require('../../../src/services/weather');
+const { mockWeatherSuccess, mockWeatherError, cleanMocks } = require('../../helpers/nock-mocks');
+
+describe('WeatherService', () => {
+  beforeEach(() => {
+    clearWeatherCache();
+    cleanMocks();
+  });
+  afterAll(() => nock.restore());
+
+  describe('getWeather', () => {
+    test('should return weather data for valid coordinates', async () => {
+      mockWeatherSuccess(37.4056, -122.0775);
+
+      const result = await getWeather(37.4056, -122.0775);
+
+      expect(result).not.toBeNull();
+      expect(result).toHaveProperty('temperature', 18.5);
+      expect(result).toHaveProperty('temperatureUnit', '°C');
+      expect(result).toHaveProperty('condition', 'Mainly clear');
+      expect(result).toHaveProperty('windSpeed', 5.2);
+      expect(result).toHaveProperty('humidity', 65);
+      expect(result.cached).toBe(false);
+    });
+
+    test('should return cached result on second call without hitting network', async () => {
+      mockWeatherSuccess(37.4056, -122.0775);
+
+      await getWeather(37.4056, -122.0775);
+      // No nock registered for this call — would throw if network were hit
+      const result = await getWeather(37.4056, -122.0775);
+
+      expect(result).not.toBeNull();
+      expect(result.cached).toBe(true);
+      expect(result).toHaveProperty('temperature', 18.5);
+    });
+
+    test('should cache different coordinates independently', async () => {
+      mockWeatherSuccess(37.4056, -122.0775);
+      mockWeatherSuccess(40.7128, -74.006);
+
+      const result1 = await getWeather(37.4056, -122.0775);
+      const result2 = await getWeather(40.7128, -74.006);
+
+      expect(result1.cached).toBe(false);
+      expect(result2.cached).toBe(false);
+    });
+
+    test('should return null on API error response', async () => {
+      mockWeatherError(37.4056, -122.0775, 500);
+
+      const result = await getWeather(37.4056, -122.0775);
+
+      expect(result).toBeNull();
+    });
+
+    test('should return null on network error', async () => {
+      nock('https://api.open-meteo.com')
+        .get('/v1/forecast')
+        .query(true)
+        .replyWithError(Object.assign(new Error('ECONNREFUSED'), { code: 'ECONNREFUSED' }));
+
+      const result = await getWeather(37.4056, -122.0775);
+
+      expect(result).toBeNull();
+    });
+
+    test('should map known WMO weather codes to descriptions', async () => {
+      mockWeatherSuccess(37.4056, -122.0775, { weather_code: 95 });
+
+      const result = await getWeather(37.4056, -122.0775);
+
+      expect(result.condition).toBe('Thunderstorm');
+    });
+
+    test('should return "Unknown" for unrecognised weather codes', async () => {
+      mockWeatherSuccess(37.4056, -122.0775, { weather_code: 999 });
+
+      const result = await getWeather(37.4056, -122.0775);
+
+      expect(result.condition).toBe('Unknown');
+    });
+  });
+});

--- a/tests/unit/services/weather.test.js
+++ b/tests/unit/services/weather.test.js
@@ -19,6 +19,7 @@ describe('WeatherService', () => {
       expect(result).toHaveProperty('temperature', 18.5);
       expect(result).toHaveProperty('temperatureUnit', '°C');
       expect(result).toHaveProperty('condition', 'Mainly clear');
+      expect(result).toHaveProperty('icon', '🌤️');
       expect(result).toHaveProperty('windSpeed', 5.2);
       expect(result).toHaveProperty('humidity', 65);
       expect(result.cached).toBe(false);
@@ -66,20 +67,22 @@ describe('WeatherService', () => {
       expect(result).toBeNull();
     });
 
-    test('should map known WMO weather codes to descriptions', async () => {
+    test('should map known WMO weather codes to descriptions and icons', async () => {
       mockWeatherSuccess(37.4056, -122.0775, { weather_code: 95 });
 
       const result = await getWeather(37.4056, -122.0775);
 
       expect(result.condition).toBe('Thunderstorm');
+      expect(result.icon).toBe('⛈️');
     });
 
-    test('should return "Unknown" for unrecognised weather codes', async () => {
+    test('should return "Unknown" condition and fallback icon for unrecognised weather codes', async () => {
       mockWeatherSuccess(37.4056, -122.0775, { weather_code: 999 });
 
       const result = await getWeather(37.4056, -122.0775);
 
       expect(result.condition).toBe('Unknown');
+      expect(result.icon).toBe('🌡️');
     });
   });
 });


### PR DESCRIPTION
## Summary

Adds live weather to the app — fetching current conditions from the free Open-Meteo API and displaying them as a floating overlay on the globe (top-left).

**Backend** (`src/services/weather.js`) — new service that calls `GET https://api.open-meteo.com/v1/forecast` with the user's detected coordinates, caches results for 30 minutes per coordinate pair, and maps WMO weather codes to both human-readable descriptions and emoji icons. Integrated into `timezoneController.js` as a non-blocking call; `weather: null` is returned if Open-Meteo is unavailable.

**Frontend** (`src/public/index.html`) — a dark glassmorphism box anchored to the top-left of the globe shows the weather emoji icon, temperature, condition, wind speed, and humidity. The info strip retains its existing 4 chips unchanged.

## API change

`GET /api/timezone` response gains a `weather` field:
```json
{
  "weather": {
    "temperature": 18.5,
    "temperatureUnit": "°C",
    "condition": "Partly cloudy",
    "icon": "⛅",
    "windSpeed": 5.2,
    "windUnit": "mp/h",
    "humidity": 65,
    "cached": false
  }
}
```
`weather` is `null` when Open-Meteo is unreachable. No API key required; no new CDN dependencies.

## Test plan

- [x] `curl http://localhost:3000/api/timezone` — response includes `weather` with `icon`, `condition`, `temperature`
- [ ] Second request within 30 min — `weather.cached: true`
- [x] Globe shows weather overlay top-left: emoji icon + temperature on the first row, condition below, wind and humidity as secondary details
- [ ] Simulate Open-Meteo failure — endpoint still returns 200 with `weather: null`, overlay remains hidden

Closes #127, Closes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)