### PR TITLE
feat(ui): globe texture toggle — Terrain & Night with high-quality NASA imagery (Closes #74)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,6 +97,9 @@ dist
 # Stores VSCode versions used for testing VSCode extensions
 .vscode-test
 
+# Globe textures (large binary assets — download via scripts/download-textures.sh)
+src/public/textures/
+
 # macOS
 .DS_Store
 

--- a/scripts/download-textures.sh
+++ b/scripts/download-textures.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Downloads high-quality Earth textures into src/public/textures/.
+# The textures/ directory is gitignored — run this script after cloning or
+# if the textures directory is missing.
+#
+# Sources: NASA Visible Earth (public domain)
+#   Satellite: Blue Marble Next Generation, August 2004 (5400×2700)
+#   Terrain:   Land Shallow Topo (2048×1024) — natural colour with elevation
+#   Night:     Black Marble / Earth at Night 2012 (3600×1800)
+
+set -euo pipefail
+
+DEST="$(cd "$(dirname "$0")/.." && pwd)/src/public/textures"
+mkdir -p "$DEST"
+
+echo "Downloading Earth textures to $DEST …"
+
+curl -L --progress-bar --max-time 120 \
+  -o "$DEST/earth-satellite.jpg" \
+  "https://eoimages.gsfc.nasa.gov/images/imagerecords/74000/74117/world.200408.3x5400x2700.jpg"
+
+curl -L --progress-bar --max-time 60 \
+  -o "$DEST/earth-terrain.jpg" \
+  "https://eoimages.gsfc.nasa.gov/images/imagerecords/57000/57752/land_shallow_topo_2048.jpg"
+
+curl -L --progress-bar --max-time 60 \
+  -o "$DEST/earth-night.jpg" \
+  "https://eoimages.gsfc.nasa.gov/images/imagerecords/79000/79765/dnb_land_ocean_ice.2012.3600x1800.jpg"
+
+echo "Done."
+ls -lh "$DEST"

--- a/scripts/download-textures.sh
+++ b/scripts/download-textures.sh
@@ -4,9 +4,8 @@
 # if the textures directory is missing.
 #
 # Sources: NASA Visible Earth (public domain)
-#   Satellite: Blue Marble Next Generation, August 2004 (5400×2700)
-#   Terrain:   Land Shallow Topo (2048×1024) — natural colour with elevation
-#   Night:     Black Marble / Earth at Night 2012 (3600×1800)
+#   Terrain: Blue Marble Next Generation, August 2004 (5400×2700)
+#   Night:   Black Marble / Earth at Night 2012 (3600×1800)
 
 set -euo pipefail
 
@@ -18,10 +17,6 @@ echo "Downloading Earth textures to $DEST …"
 curl -L --progress-bar --max-time 120 \
   -o "$DEST/earth-satellite.jpg" \
   "https://eoimages.gsfc.nasa.gov/images/imagerecords/74000/74117/world.200408.3x5400x2700.jpg"
-
-curl -L --progress-bar --max-time 60 \
-  -o "$DEST/earth-terrain.jpg" \
-  "https://eoimages.gsfc.nasa.gov/images/imagerecords/57000/57752/land_shallow_topo_2048.jpg"
 
 curl -L --progress-bar --max-time 60 \
   -o "$DEST/earth-night.jpg" \

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -295,7 +295,7 @@
         <div id="globe-container"></div>
         <div class="globe-loading" id="globe-loading">Detecting your location…</div>
         <div id="weather-overlay" class="weather-overlay" hidden></div>
-        <button id="texture-btn" class="texture-btn" hidden>Satellite ▸</button>
+        <button id="texture-btn" class="texture-btn" hidden>Terrain ▸</button>
         <div id="error-banner" class="error-banner" hidden></div>
     </div>
 
@@ -333,9 +333,8 @@
         let globeInstance = null;
 
         const TEXTURES = [
-            { label: 'Satellite', url: '/textures/earth-satellite.jpg' },
-            { label: 'Terrain',   url: '/textures/earth-terrain.jpg'   },
-            { label: 'Night',     url: '/textures/earth-night.jpg'     },
+            { label: 'Terrain', url: '/textures/earth-satellite.jpg' },
+            { label: 'Night',   url: '/textures/earth-night.jpg'     },
         ];
         let textureIndex = 0;
 

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -333,9 +333,9 @@
         let globeInstance = null;
 
         const TEXTURES = [
-            { label: 'Satellite', url: '//unpkg.com/three-globe/example/img/earth-blue-marble.jpg' },
-            { label: 'Terrain',   url: '//unpkg.com/three-globe/example/img/earth-topology.png'   },
-            { label: 'Night',     url: '//unpkg.com/three-globe/example/img/earth-night.jpg'      },
+            { label: 'Satellite', url: '/textures/earth-satellite.jpg' },
+            { label: 'Terrain',   url: '/textures/earth-terrain.jpg'   },
+            { label: 'Night',     url: '/textures/earth-night.jpg'     },
         ];
         let textureIndex = 0;
 
@@ -444,7 +444,7 @@
                 const container = document.getElementById('globe-container');
 
                 globeInstance = Globe()
-                    .globeImageUrl('//unpkg.com/three-globe/example/img/earth-blue-marble.jpg')
+                    .globeImageUrl('/textures/earth-satellite.jpg')
                     .backgroundImageUrl('//unpkg.com/three-globe/example/img/night-sky.png')
                     .onGlobeReady(() => {
                         container.classList.add('ready');

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -82,6 +82,29 @@
             pointer-events: none;
         }
 
+        /* ── Globe texture toggle button ── */
+        .texture-btn {
+            position: absolute;
+            top: 12px;
+            right: 12px;
+            z-index: 5;
+            background: rgba(102, 126, 234, 0.85);
+            color: white;
+            border: none;
+            border-radius: 20px;
+            padding: 6px 14px;
+            font-size: 0.78em;
+            font-weight: 600;
+            cursor: pointer;
+            backdrop-filter: blur(4px);
+            letter-spacing: 0.5px;
+            transition: background 0.2s ease;
+        }
+
+        .texture-btn:hover {
+            background: rgba(102, 126, 234, 1);
+        }
+
         /* ── Globe floating location label ── */
         .globe-label {
             background: rgba(255, 255, 255, 0.96);
@@ -272,6 +295,7 @@
         <div id="globe-container"></div>
         <div class="globe-loading" id="globe-loading">Detecting your location…</div>
         <div id="weather-overlay" class="weather-overlay" hidden></div>
+        <button id="texture-btn" class="texture-btn" hidden>Satellite ▸</button>
         <div id="error-banner" class="error-banner" hidden></div>
     </div>
 
@@ -307,6 +331,20 @@
     <script src="https://cdn.jsdelivr.net/npm/globe.gl@2/dist/globe.gl.min.js"></script>
     <script>
         let globeInstance = null;
+
+        const TEXTURES = [
+            { label: 'Satellite', url: '//unpkg.com/three-globe/example/img/earth-blue-marble.jpg' },
+            { label: 'Terrain',   url: '//unpkg.com/three-globe/example/img/earth-topology.png'   },
+            { label: 'Night',     url: '//unpkg.com/three-globe/example/img/earth-night.jpg'      },
+        ];
+        let textureIndex = 0;
+
+        function cycleTexture() {
+            textureIndex = (textureIndex + 1) % TEXTURES.length;
+            const { label, url } = TEXTURES[textureIndex];
+            globeInstance.globeImageUrl(url);
+            document.getElementById('texture-btn').textContent = `${label} ▸`;
+        }
 
         async function fetchTimezoneInfo() {
             let errorMessage = null;
@@ -411,6 +449,10 @@
                     .onGlobeReady(() => {
                         container.classList.add('ready');
                         document.getElementById('globe-loading')?.remove();
+
+                        const btn = document.getElementById('texture-btn');
+                        btn.removeAttribute('hidden');
+                        btn.addEventListener('click', cycleTexture);
 
                         // Keep the globe stationary on the user's location
                         globeInstance.controls().autoRotate = false;


### PR DESCRIPTION
## Summary

Adds a pill-shaped button in the top-right corner of the globe that toggles between two texture modes on each click:

- **Terrain** (default) — NASA Blue Marble Next Generation, August 2004 at 5400×2700, self-hosted. Shows Earth's surface without cloud cover with natural colour and shaded relief.
- **Night** — NASA Black Marble / Earth at Night 2012 composite at 3600×1800, self-hosted. Shows city lights against dark oceans.

Textures are stored in `src/public/textures/` (gitignored to keep the repo lean) and reproduced via `scripts/download-textures.sh`. The `unpkg.com` CDN is no longer used for globe textures.

The button appears after the globe finishes loading and is hidden until then. No backend changes.

## Test plan

- [x] Globe loads with Terrain (Blue Marble) texture and the "Terrain ▸" button visible in the top-right
- [x] Clicking toggles to Night (city lights) — button updates to "Night ▸"
- [x] Clicking again returns to Terrain — button updates to "Terrain ▸"
- [x] Location pin, ripple rings, floating city/time label, and weather overlay remain visible across both textures
- [x] Button is hidden while globe is loading (only appears on `onGlobeReady`)
- [x] `bash scripts/download-textures.sh` fetches both textures into `src/public/textures/`

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)